### PR TITLE
chore: publish only lib directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "polymath",
     "ethereum"
   ],
+  "files": [
+    "/lib"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
This PR modifies package.json so that only the `lib` folder is published to npm. Just for clarification, the following files/folders are **ALWAYS** published no matter what, so there's no need to add them to the "files" array:

- package.json
- README (and its variants)
- CHANGELOG (and its variants)
- LICENSE / LICENCE

More information:

https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d