### PR TITLE
refactor: make enum naming consistent

### DIFF
--- a/src/contract_wrappers/modules/checkpoint/dividend_checkpoint_wrapper.ts
+++ b/src/contract_wrappers/modules/checkpoint/dividend_checkpoint_wrapper.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@0x/utils';
 import ModuleWrapper from '../module_wrapper';
 import assert from '../../../utils/assert';
-import { TxParams, DividendCheckpointBaseContract, Perms, PERCENTAGE_DECIMALS } from '../../../types';
+import { TxParams, DividendCheckpointBaseContract, Perm, PERCENTAGE_DECIMALS } from '../../../types';
 import {
   numberToBigNumber,
   dateToBigNumber,
@@ -241,12 +241,12 @@ export default abstract class DividendCheckpointWrapper extends ModuleWrapper {
   };
 
   public createCheckpoint = async (params: TxParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Checkpoint), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Checkpoint), 'Caller is not allowed');
     return (await this.contract).createCheckpoint.sendTransactionAsync(params.txData, params.safetyFactor);
   };
 
   public setDefaultExcluded = async (params: SetDefaultExcludedParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     assert.assert(params.excluded.length <= EXCLUDED_ADDRESS_LIMIT, 'Too many excluded addresses');
     params.excluded.forEach(address => assert.isNonZeroETHAddressHex('excluded', address));
     assert.areThereDuplicatedStrings('excluded', params.excluded);
@@ -258,7 +258,7 @@ export default abstract class DividendCheckpointWrapper extends ModuleWrapper {
   };
 
   public setWithholding = async (params: SetWithholdingParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     assert.assert(params.investors.length === params.withholding.length, 'Mismatched input lengths');
     params.withholding.forEach(withholding => assert.isPercentage('withholding tax', withholding));
     return (await this.contract).setWithholding.sendTransactionAsync(
@@ -270,7 +270,7 @@ export default abstract class DividendCheckpointWrapper extends ModuleWrapper {
   };
 
   public setWithholdingFixed = async (params: SetWithholdingFixedParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     assert.isPercentage('withholding tax', params.withholding);
     return (await this.contract).setWithholdingFixed.sendTransactionAsync(
       params.investors,
@@ -281,7 +281,7 @@ export default abstract class DividendCheckpointWrapper extends ModuleWrapper {
   };
 
   public pushDividendPaymentToAddresses = async (params: PushDividendPaymentToAddressesParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Distribute), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Distribute), 'Caller is not allowed');
     params.payees.forEach(address => assert.isNonZeroETHAddressHex('payees', address));
     await this.checkValidDividend(params.dividendIndex);
     return (await this.contract).pushDividendPaymentToAddresses.sendTransactionAsync(
@@ -293,7 +293,7 @@ export default abstract class DividendCheckpointWrapper extends ModuleWrapper {
   };
 
   public pushDividendPayment = async (params: PushDividendPaymentParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Distribute), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Distribute), 'Caller is not allowed');
     await this.checkValidDividend(params.dividendIndex);
     return (await this.contract).pushDividendPayment.sendTransactionAsync(
       numberToBigNumber(params.dividendIndex),

--- a/src/contract_wrappers/modules/checkpoint/erc20_dividend_checkpoint_wrapper.ts
+++ b/src/contract_wrappers/modules/checkpoint/erc20_dividend_checkpoint_wrapper.ts
@@ -26,7 +26,7 @@ import {
   EventCallback,
   Subscribe,
   GetLogs,
-  Perms,
+  Perm,
 } from '../../../types';
 import { numberToBigNumber, dateToBigNumber, stringToBytes32, valueToWei } from '../../../utils/convert';
 
@@ -194,7 +194,7 @@ export default class ERC20DividendCheckpointWrapper extends DividendCheckpointWr
   };
 
   public createDividend = async (params: CreateDividendParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     await this.checkIfDividendIsValid(
       params.expiry,
       params.maturity,
@@ -216,7 +216,7 @@ export default class ERC20DividendCheckpointWrapper extends DividendCheckpointWr
   };
 
   public createDividendWithCheckpoint = async (params: CreateDividendWithCheckpointParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     await this.checkIfDividendIsValid(
       params.expiry,
       params.maturity,
@@ -240,7 +240,7 @@ export default class ERC20DividendCheckpointWrapper extends DividendCheckpointWr
   };
 
   public createDividendWithExclusions = async (params: CreateDividendWithExclusionsParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     await this.checkIfDividendIsValid(
       params.expiry,
       params.maturity,
@@ -267,7 +267,7 @@ export default class ERC20DividendCheckpointWrapper extends DividendCheckpointWr
   public createDividendWithCheckpointAndExclusions = async (
     params: CreateDividendWithCheckpointAndExclusionsParams,
   ) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     await this.checkIfDividendIsValid(
       params.expiry,
       params.maturity,

--- a/src/contract_wrappers/modules/checkpoint/ether_dividend_checkpoint_wrapper.ts
+++ b/src/contract_wrappers/modules/checkpoint/ether_dividend_checkpoint_wrapper.ts
@@ -30,7 +30,7 @@ import {
   EventCallback,
   Subscribe,
   GetLogs,
-  Perms,
+  Perm,
 } from '../../../types';
 import { numberToBigNumber, dateToBigNumber, stringToBytes32, valueToWei } from '../../../utils/convert';
 
@@ -251,7 +251,7 @@ export default class EtherDividendCheckpointWrapper extends DividendCheckpointWr
   }
 
   public createDividend = async (params: CreateDividendParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     const txPayableData = {
       ...params.txData,
       value: valueToWei(params.value, await this.getDecimals()),
@@ -267,7 +267,7 @@ export default class EtherDividendCheckpointWrapper extends DividendCheckpointWr
   };
 
   public createDividendWithCheckpoint = async (params: CreateDividendWithCheckpointParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     const txPayableData = {
       ...params.txData,
       value: valueToWei(params.value, await this.getDecimals()),
@@ -284,7 +284,7 @@ export default class EtherDividendCheckpointWrapper extends DividendCheckpointWr
   };
 
   public createDividendWithExclusions = async (params: CreateDividendWithExclusionsParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     const txPayableData = {
       ...params.txData,
       value: valueToWei(params.value, await this.getDecimals()),
@@ -310,7 +310,7 @@ export default class EtherDividendCheckpointWrapper extends DividendCheckpointWr
   public createDividendWithCheckpointAndExclusions = async (
     params: CreateDividendWithCheckpointAndExclusionsParams,
   ) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Manage), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Manage), 'Caller is not allowed');
     const txPayableData = {
       ...params.txData,
       value: valueToWei(params.value, await this.getDecimals()),

--- a/src/contract_wrappers/modules/module_wrapper.ts
+++ b/src/contract_wrappers/modules/module_wrapper.ts
@@ -38,7 +38,7 @@ export default class ModuleWrapper extends ContractWrapper {
     return this.contractFactory.getPolyTokenContract();
   };
 
-  protected detailedErc20TokenContract = async (address: string): Promise<DetailedERC20Contract> => {
+  protected detailedERC20TokenContract = async (address: string): Promise<DetailedERC20Contract> => {
     return this.contractFactory.getDetailedERC20Contract(address);
   };
 

--- a/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper.ts
@@ -20,7 +20,7 @@ import {
   EventCallback,
   GetLogs,
   Subscribe,
-  Perms,
+  Perm,
 } from '../../../types';
 import { numberToBigNumber, stringToBytes32, bytes32ToString, stringArrayToBytes32Array } from '../../../utils/convert';
 
@@ -54,7 +54,7 @@ interface GetGeneralPermissionManagerLogsAsyncParams extends GetLogs {
   (params: GetAddDelegateLogsAsyncParams): Promise<LogWithDecodedArgs<GeneralPermissionManagerAddDelegateEventArgs>[]>;
 }
 
-interface PermsParams {
+interface PermParams {
   module: string;
   delegate: string;
   permission: string;
@@ -132,7 +132,7 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
     this.contract = contract;
   }
 
-  public perms = async (params: PermsParams) => {
+  public perms = async (params: PermParams) => {
     assert.isETHAddressHex('module', params.module);
     assert.isETHAddressHex('delegate', params.delegate);
     return (await this.contract).perms.callAsync(params.module, params.delegate, stringToBytes32(params.permission));
@@ -147,7 +147,7 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
     return (await this.contract).delegateDetails.callAsync(params.delegate);
   };
 
-  public checkPermission = async (params: PermsParams) => {
+  public checkPermission = async (params: PermParams) => {
     assert.isETHAddressHex('delegate', params.delegate);
     assert.isETHAddressHex('module', params.module);
     return (await this.contract).checkPermission.callAsync(
@@ -158,7 +158,7 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
   };
 
   public addDelegate = async (params: AddDelegateParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.ChangePermission), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.ChangePermission), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('delegate', params.delegate);
     assert.assert(params.details.length > 0, '0 value not allowed');
     assert.assert(!await (await this.contract).checkDelegate.callAsync(params.delegate), 'Already present');
@@ -171,7 +171,7 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
   };
 
   public deleteDelegate = async (params: DelegateTxParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.ChangePermission), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.ChangePermission), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('delegate', params.delegate);
     assert.assert(await (await this.contract).checkDelegate.callAsync(params.delegate), 'Delegate does not exist');
     return (await this.contract).deleteDelegate.sendTransactionAsync(
@@ -187,7 +187,7 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
   };
 
   public changePermission = async (params: ChangePermissionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.ChangePermission), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.ChangePermission), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('delegate', params.delegate);
     assert.isETHAddressHex('module', params.module);
     return (await this.contract).changePermission.sendTransactionAsync(
@@ -201,7 +201,7 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
   };
 
   public changePermissionMulti = async (params: ChangePermissionMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.ChangePermission), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.ChangePermission), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('delegate', params.delegate);
     params.modules.forEach(address => assert.isETHAddressHex('modules', address));
     assert.assert(params.modules.length > 0, '0 length is not allowed');

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper.ts
@@ -1044,7 +1044,7 @@ export default class USDTieredSTOWrapper extends STOWrapper {
         assert.assert(stoDetails.isRaisedInSC, 'USD Not Allowed');
         assert.assert(usdToken !== null, 'USD Token Address must exist');
         if (usdToken) {
-          const scTokenBalance = await (await this.detailedErc20TokenContract(usdToken)).balanceOf.callAsync(from);
+          const scTokenBalance = await (await this.detailedERC20TokenContract(usdToken)).balanceOf.callAsync(from);
           assert.assert(
             scTokenBalance.isGreaterThanOrEqualTo(investmentValue),
             'Budget less than amount unable to transfer fee',

--- a/src/contract_wrappers/modules/transfer_manager/__tests__/volume_restriction_transfer_manager_wrapper.test.ts
+++ b/src/contract_wrappers/modules/transfer_manager/__tests__/volume_restriction_transfer_manager_wrapper.test.ts
@@ -4,7 +4,7 @@ import { Web3Wrapper } from '@0x/web3-wrapper';
 import { BigNumber } from '@0x/utils';
 import { VolumeRestrictionTMContract, SecurityTokenContract, PolyTokenEvents } from '@polymathnetwork/abi-wrappers';
 import { MockedCallMethod, MockedSendMethod, getMockedPolyResponse } from '../../../../test_utils/mocked_methods';
-import { RestrictionTypes } from '../../../../types';
+import { RestrictionType } from '../../../../types';
 import ModuleWrapper from '../../module_wrapper';
 import ContractFactory from '../../../../factories/contractFactory';
 import VolumeRestrictionTransferManagerWrapper from '../volume_restriction_transfer_manager_wrapper';
@@ -309,7 +309,7 @@ describe('VolumeRestrictionTransferManagerWrapper', () => {
       expect(result.startTime).toEqual(bigNumberToDate(startTime));
       expect(result.rollingPeriodInDays).toEqual(rollingPeriodInDays.toNumber());
       expect(result.endTime).toEqual(bigNumberToDate(endTime));
-      expect(result.restrictionType).toEqual(RestrictionTypes.Fixed);
+      expect(result.restrictionType).toEqual(RestrictionType.Fixed);
       // Verifications
       verify(mockedContract.individualRestriction).once();
       verify(mockedMethod.callAsync(mockedParams.holder)).once();
@@ -358,7 +358,7 @@ describe('VolumeRestrictionTransferManagerWrapper', () => {
       expect(result.startTime).toEqual(bigNumberToDate(startTime));
       expect(result.rollingPeriodInDays).toEqual(rollingPeriodInDays.toNumber());
       expect(result.endTime).toEqual(bigNumberToDate(endTime));
-      expect(result.restrictionType).toEqual(RestrictionTypes.Fixed);
+      expect(result.restrictionType).toEqual(RestrictionType.Fixed);
       // Verifications
       verify(mockedContract.defaultRestriction).once();
       verify(mockedMethod.callAsync()).once();
@@ -407,7 +407,7 @@ describe('VolumeRestrictionTransferManagerWrapper', () => {
       expect(result.startTime).toEqual(bigNumberToDate(startTime));
       expect(result.rollingPeriodInDays).toEqual(rollingPeriodInDays.toNumber());
       expect(result.endTime).toEqual(bigNumberToDate(endTime));
-      expect(result.restrictionType).toEqual(RestrictionTypes.Fixed);
+      expect(result.restrictionType).toEqual(RestrictionType.Fixed);
       // Verifications
       verify(mockedContract.defaultDailyRestriction).once();
       verify(mockedMethod.callAsync()).once();
@@ -483,7 +483,7 @@ describe('VolumeRestrictionTransferManagerWrapper', () => {
       expect(result.startTime).toEqual(bigNumberToDate(startTime));
       expect(result.rollingPeriodInDays).toEqual(rollingPeriodInDays.toNumber());
       expect(result.endTime).toEqual(bigNumberToDate(endTime));
-      expect(result.restrictionType).toEqual(RestrictionTypes.Fixed);
+      expect(result.restrictionType).toEqual(RestrictionType.Fixed);
       // Verifications
       verify(mockedContract.individualDailyRestriction).once();
       verify(mockedMethod.callAsync(mockedParams.holder)).once();

--- a/src/contract_wrappers/modules/transfer_manager/count_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/count_transfer_manager_wrapper.ts
@@ -21,7 +21,7 @@ import {
   EventCallback,
   Subscribe,
   GetLogs,
-  Perms,
+  Perm,
 } from '../../../types';
 import { numberToBigNumber, valueToWei } from '../../../utils/convert';
 
@@ -137,7 +137,7 @@ export default class CountTransferManagerWrapper extends ModuleWrapper {
   };
 
   public changeHolderCount = async (params: ChangeHolderCountParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     return (await this.contract).changeHolderCount.sendTransactionAsync(
       numberToBigNumber(params.maxHolderCount),
       params.txData,

--- a/src/contract_wrappers/modules/transfer_manager/general_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/general_transfer_manager_wrapper.ts
@@ -35,7 +35,7 @@ import {
   EventCallback,
   Subscribe,
   GetLogs,
-  Perms,
+  Perm,
 } from '../../../types';
 
 interface ChangeIssuanceAddressSubscribeAsyncParams extends SubscribeAsyncParams {
@@ -371,7 +371,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
   };
 
   public changeDefaults = async (params: ChangeDefaultsParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Flags), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Flags), 'Caller is not allowed');
     return (await this.contract).changeDefaults.sendTransactionAsync(
       dateToBigNumber(params.defaultFromTime),
       dateToBigNumber(params.defaultToTime),
@@ -382,7 +382,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
 
   public changeIssuanceAddress = async (params: ChangeIssuanceAddressParams) => {
     assert.isETHAddressHex('issuanceAddress', params.issuanceAddress);
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Flags), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Flags), 'Caller is not allowed');
     return (await this.contract).changeIssuanceAddress.sendTransactionAsync(
       params.issuanceAddress,
       params.txData,
@@ -392,7 +392,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
 
   public changeSigningAddress = async (params: ChangeSigningAddressParams) => {
     assert.isETHAddressHex('signingAddress', params.signingAddress);
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Flags), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Flags), 'Caller is not allowed');
     return (await this.contract).changeSigningAddress.sendTransactionAsync(
       params.signingAddress,
       params.txData,
@@ -401,7 +401,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
   };
 
   public changeAllowAllTransfers = async (params: ChangeAllowAllTransfersParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Flags), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Flags), 'Caller is not allowed');
     return (await this.contract).changeAllowAllTransfers.sendTransactionAsync(
       params.allowAllTransfers,
       params.txData,
@@ -410,7 +410,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
   };
 
   public changeAllowAllWhitelistTransfers = async (params: ChangeAllowAllWhitelistTransfersParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Flags), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Flags), 'Caller is not allowed');
     return (await this.contract).changeAllowAllWhitelistTransfers.sendTransactionAsync(
       params.allowAllWhitelistTransfers,
       params.txData,
@@ -419,7 +419,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
   };
 
   public changeAllowAllWhitelistIssuances = async (params: ChangeAllowAllWhitelistIssuancesParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Flags), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Flags), 'Caller is not allowed');
     return (await this.contract).changeAllowAllWhitelistIssuances.sendTransactionAsync(
       params.allowAllWhitelistIssuances,
       params.txData,
@@ -428,7 +428,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
   };
 
   public changeAllowAllBurnTransfers = async (params: ChangeAllowAllBurnTransfersParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Flags), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Flags), 'Caller is not allowed');
     return (await this.contract).changeAllowAllBurnTransfers.sendTransactionAsync(
       params.allowAllBurnTransfers,
       params.txData,
@@ -453,7 +453,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
 
   public modifyWhitelist = async (params: ModifyWhitelistParams) => {
     assert.isNonZeroETHAddressHex('investor', params.investor);
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Whitelist), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Whitelist), 'Caller is not allowed');
     assert.isLessThanMax64BytesDate('canSendAfter', params.canSendAfter);
     assert.isLessThanMax64BytesDate('canReceiveAfter', params.canReceiveAfter);
     assert.isLessThanMax64BytesDate('expiryTime', params.expiryTime);
@@ -469,7 +469,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
   };
 
   public modifyWhitelistMulti = async (params: ModifyWhitelistMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Whitelist), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Whitelist), 'Caller is not allowed');
     params.investors.forEach(address => assert.isNonZeroETHAddressHex('investors', address));
     assert.assert(
       params.canSendAfters.length === params.canReceiveAfters.length &&
@@ -493,7 +493,7 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
 
   public modifyWhitelistSigned = async (params: ModifyWhitelistSignedParams) => {
     assert.isNonZeroETHAddressHex('investor', params.investor);
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Whitelist), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Whitelist), 'Caller is not allowed');
     assert.isLessThanMax64BytesDate('canSendAfter', params.canSendAfter);
     assert.isLessThanMax64BytesDate('canReceiveAfter', params.canReceiveAfter);
     assert.isLessThanMax64BytesDate('expiryTime', params.expiryTime);

--- a/src/contract_wrappers/modules/transfer_manager/manual_approval_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/manual_approval_transfer_manager_wrapper.ts
@@ -23,7 +23,7 @@ import {
   EventCallback,
   Subscribe,
   GetLogs,
-  Perms,
+  Perm,
 } from '../../../types';
 import {
   bigNumberToDate,
@@ -257,7 +257,7 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
   };
 
   public addManualApproval = async (params: AddManualApprovalParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.TransferApproval), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.TransferApproval), 'Caller is not allowed');
     assert.isETHAddressHex('from', params.from);
     assert.isNonZeroETHAddressHex('to', params.to);
     assert.isFutureDate(params.expiryTime, 'ExpiryTime must be in the future');
@@ -276,7 +276,7 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
   };
 
   public addManualApprovalMulti = async (params: AddManualApprovalMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.TransferApproval), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.TransferApproval), 'Caller is not allowed');
     params.from.forEach(address => assert.isETHAddressHex('from', address));
     params.to.forEach(address => assert.isNonZeroETHAddressHex('to', address));
     assert.assert(
@@ -308,7 +308,7 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
   };
 
   public modifyManualApproval = async (params: ModifyManualApprovalParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.TransferApproval), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.TransferApproval), 'Caller is not allowed');
     assert.isETHAddressHex('from', params.from);
     assert.isNonZeroETHAddressHex('to', params.to);
     assert.isFutureDate(params.expiryTime, 'ExpiryTime must be in the future');
@@ -327,7 +327,7 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
   };
 
   public modifyManualApprovalMulti = async (params: ModifyManualApprovalMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.TransferApproval), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.TransferApproval), 'Caller is not allowed');
     params.from.forEach(address => assert.isETHAddressHex('from', address));
     params.to.forEach(address => assert.isNonZeroETHAddressHex('to', address));
     assert.assert(
@@ -357,7 +357,7 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
   };
 
   public revokeManualApproval = async (params: RevokeManualApprovalParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.TransferApproval), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.TransferApproval), 'Caller is not allowed');
     assert.isETHAddressHex('from', params.from);
     assert.isETHAddressHex('to', params.to);
     await this.checkApprovalDoesExist(params.from, params.to);
@@ -370,7 +370,7 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
   };
 
   public revokeManualApprovalMulti = async (params: RevokeManualApprovalMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.TransferApproval), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.TransferApproval), 'Caller is not allowed');
     params.from.forEach(address => assert.isETHAddressHex('from', address));
     params.to.forEach(address => assert.isETHAddressHex('to', address));
     assert.assert(params.to.length === params.from.length, 'To and From address arrays must have the same length');

--- a/src/contract_wrappers/modules/transfer_manager/percentage_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/percentage_transfer_manager_wrapper.ts
@@ -23,7 +23,7 @@ import {
   EventCallback,
   Subscribe,
   GetLogs,
-  Perms,
+  Perm,
   PERCENTAGE_DECIMALS,
 } from '../../../types';
 import { valueToWei, weiToValue } from '../../../utils/convert';
@@ -193,7 +193,7 @@ export default class PercentageTransferManagerWrapper extends ModuleWrapper {
   };
 
   public changeHolderPercentage = async (params: ChangeHolderPercentageParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isPercentage('maxHolderPercentage', params.maxHolderPercentage);
     return (await this.contract).changeHolderPercentage.sendTransactionAsync(
       valueToWei(params.maxHolderPercentage, PERCENTAGE_DECIMALS),
@@ -203,7 +203,7 @@ export default class PercentageTransferManagerWrapper extends ModuleWrapper {
   };
 
   public modifyWhitelist = async (params: ModifyWhitelistParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Whitelist), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Whitelist), 'Caller is not allowed');
     assert.isETHAddressHex('investor', params.investor);
     return (await this.contract).modifyWhitelist.sendTransactionAsync(
       params.investor,
@@ -214,7 +214,7 @@ export default class PercentageTransferManagerWrapper extends ModuleWrapper {
   };
 
   public modifyWhitelistMulti = async (params: ModifyWhitelistMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Whitelist), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Whitelist), 'Caller is not allowed');
     assert.assert(
       params.investors.length === params.valids.length,
       'Array lengths are not equal for investors and valids',
@@ -229,7 +229,7 @@ export default class PercentageTransferManagerWrapper extends ModuleWrapper {
   };
 
   public setAllowPrimaryIssuance = async (params: SetAllowPrimaryIssuanceParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.assert(
       (await this.allowPrimaryIssuance()) !== params.allowPrimaryIssuance,
       'AllowPrimaryIssuance value must change ',

--- a/src/contract_wrappers/modules/transfer_manager/volume_restriction_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/volume_restriction_transfer_manager_wrapper.ts
@@ -42,8 +42,8 @@ import {
   EventCallback,
   Subscribe,
   GetLogs,
-  Perms,
-  RestrictionTypes,
+  Perm,
+  RestrictionType,
   PERCENTAGE_DECIMALS,
 } from '../../../types';
 
@@ -268,7 +268,7 @@ interface DailyRestrictionParams extends TxParams {
   allowedTokens: BigNumber;
   startTime: Date;
   endTime: Date;
-  restrictionType: RestrictionTypes;
+  restrictionType: RestrictionType;
 }
 
 interface IndividualDailyRestrictionParams extends DailyRestrictionParams {
@@ -288,7 +288,7 @@ interface IndividualDailyRestrictionMultiParams extends TxParams {
   allowedTokens: BigNumber[];
   startTimes: Date[];
   endTimes: Date[];
-  restrictionTypes: RestrictionTypes[];
+  restrictionTypes: RestrictionType[];
 }
 
 interface IndividualRestrictionMultiParams extends IndividualDailyRestrictionMultiParams {
@@ -328,7 +328,7 @@ interface IndividualRestriction {
   startTime: Date;
   rollingPeriodInDays: number;
   endTime: Date;
-  restrictionType: RestrictionTypes;
+  restrictionType: RestrictionType;
 }
 
 // // End of return types ////
@@ -390,7 +390,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
 
   public individualRestriction = async (params: HolderIndividualRestrictionParams) => {
     const result = await (await this.contract).individualRestriction.callAsync(params.holder);
-    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionTypes.Fixed : RestrictionTypes.Percentage;
+    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionType.Fixed : RestrictionType.Percentage;
     const decimals = await this.decimalsByRestrictionType(restrictionType);
     const typedResult: IndividualRestriction = {
       allowedTokens: weiToValue(result[0], decimals),
@@ -404,7 +404,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
 
   public defaultRestriction = async () => {
     const result = await (await this.contract).defaultRestriction.callAsync();
-    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionTypes.Fixed : RestrictionTypes.Percentage;
+    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionType.Fixed : RestrictionType.Percentage;
     const decimals = await this.decimalsByRestrictionType(restrictionType);
     const typedResult: IndividualRestriction = {
       allowedTokens: weiToValue(result[0], decimals),
@@ -418,7 +418,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
 
   public defaultDailyRestriction = async () => {
     const result = await (await this.contract).defaultDailyRestriction.callAsync();
-    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionTypes.Fixed : RestrictionTypes.Percentage;
+    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionType.Fixed : RestrictionType.Percentage;
     const decimals = await this.decimalsByRestrictionType(restrictionType);
     const typedResult: IndividualRestriction = {
       allowedTokens: weiToValue(result[0], decimals),
@@ -436,7 +436,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
 
   public individualDailyRestriction = async (params: HolderIndividualRestrictionParams) => {
     const result = await (await this.contract).individualDailyRestriction.callAsync(params.holder);
-    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionTypes.Fixed : RestrictionTypes.Percentage;
+    const restrictionType = new BigNumber(result[4]).toNumber() === 0 ? RestrictionType.Fixed : RestrictionType.Percentage;
     const decimals = await this.decimalsByRestrictionType(restrictionType);
     const typedResult: IndividualRestriction = {
       allowedTokens: weiToValue(result[0], decimals),
@@ -463,7 +463,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public addIndividualRestriction = async (params: IndividualRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('holder', params.holder);
     assert.assert((await this.getExemptAddress()).includes(params.holder), 'Holder is exempt from restriction');
     this.checkRestrictionInputParams(
@@ -486,7 +486,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public addIndividualDailyRestriction = async (params: IndividualRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('holder', params.holder);
     this.checkRestrictionInputParams(params.startTime, params.allowedTokens, params.restrictionType, 1);
     const decimals = await this.decimalsByRestrictionType(params.restrictionType);
@@ -502,7 +502,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public addIndividualDailyRestrictionMulti = async (params: IndividualDailyRestrictionMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     params.holders.forEach(address => assert.isNonZeroETHAddressHex('holders', address));
     assert.assert(
       params.startTimes.length === params.allowedTokens.length &&
@@ -533,7 +533,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public addIndividualRestrictionMulti = async (params: IndividualRestrictionMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     params.holders.forEach(address => assert.isNonZeroETHAddressHex('holders', address));
     const exemptAddress = await this.getExemptAddress();
     assert.assert(exemptAddress.some(address => params.holders.includes(address)), 'Holder is exempt from restriction');
@@ -573,7 +573,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public addDefaultRestriction = async (params: RestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     this.checkRestrictionInputParams(
       params.startTime,
       params.allowedTokens,
@@ -593,7 +593,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public addDefaultDailyRestriction = async (params: DailyRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     this.checkRestrictionInputParams(params.startTime, params.allowedTokens, params.restrictionType, 1);
     const decimals = await this.decimalsByRestrictionType(params.restrictionType);
     return (await this.contract).addDefaultDailyRestriction.sendTransactionAsync(
@@ -607,7 +607,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public removeIndividualRestriction = async (params: HolderIndividualRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNotDateZero(
       (await this.individualRestriction({ holder: params.holder })).endTime,
       'Individual Restriction not set with end time',
@@ -621,7 +621,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public removeIndividualRestrictionMulti = async (params: IndividualRestrictionMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     params.holders.forEach(address => assert.isNonZeroETHAddressHex('holders', address));
     Promise.all(
       params.holders.map(async holder =>
@@ -639,7 +639,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public removeIndividualDailyRestriction = async (params: HolderIndividualRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNotDateZero(
       (await this.individualDailyRestriction({ holder: params.holder })).endTime,
       'Individual Daily Restriction not set with end time',
@@ -653,7 +653,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public removeIndividualDailyRestrictionMulti = async (params: IndividualRestrictionMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     Promise.all(
       params.holders.map(async holder =>
         assert.isNotDateZero(
@@ -671,13 +671,13 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public removeDefaultRestriction = async (params: TxParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNotDateZero((await this.defaultRestriction()).endTime, 'Individual Restriction not set with end time');
     return (await this.contract).removeDefaultRestriction.sendTransactionAsync(params.txData, params.safetyFactor);
   };
 
   public removeDefaultDailyRestriction = async (params: TxParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNotDateZero(
       (await this.defaultDailyRestriction()).endTime,
       'Individual Restriction not set with end time',
@@ -686,7 +686,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public modifyIndividualRestriction = async (params: IndividualRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('holder', params.holder);
     this.checkRestrictionInputParams(
       params.startTime,
@@ -708,7 +708,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public modifyIndividualDailyRestriction = async (params: IndividualDailyRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     assert.isNonZeroETHAddressHex('holder', params.holder);
     this.checkRestrictionInputParams(params.startTime, params.allowedTokens, params.restrictionType, 1);
     const decimals = await this.decimalsByRestrictionType(params.restrictionType);
@@ -724,7 +724,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public modifyIndividualDailyRestrictionMulti = async (params: IndividualDailyRestrictionMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     params.holders.forEach(address => assert.isNonZeroETHAddressHex('holders', address));
     assert.assert(
       params.startTimes.length === params.allowedTokens.length &&
@@ -755,7 +755,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public modifyIndividualRestrictionMulti = async (params: IndividualRestrictionMultiParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     params.holders.forEach(address => assert.isNonZeroETHAddressHex('holders', address));
     assert.assert(
       params.startTimes.length === params.allowedTokens.length &&
@@ -793,7 +793,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public modifyDefaultRestriction = async (params: RestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     this.checkRestrictionInputParams(
       params.startTime,
       params.allowedTokens,
@@ -813,7 +813,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   };
 
   public modifyDefaultDailyRestriction = async (params: DailyRestrictionParams) => {
-    assert.assert(await this.isCallerAllowed(params.txData, Perms.Admin), 'Caller is not allowed');
+    assert.assert(await this.isCallerAllowed(params.txData, Perm.Admin), 'Caller is not allowed');
     this.checkRestrictionInputParams(params.startTime, params.allowedTokens, params.restrictionType, 1);
     const decimals = await this.decimalsByRestrictionType(params.restrictionType);
     return (await this.contract).modifyDefaultDailyRestriction.sendTransactionAsync(
@@ -870,7 +870,7 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
     const result = await (await this.contract).getRestrictedData.callAsync();
     const restrictionType = [];
     for (let i = 0; i < result[0].length; i += 1) {
-      const type = new BigNumber(result[5][i]).toNumber() === 0 ? RestrictionTypes.Fixed : RestrictionTypes.Percentage;
+      const type = new BigNumber(result[5][i]).toNumber() === 0 ? RestrictionType.Fixed : RestrictionType.Percentage;
       restrictionType.push(this.decimalsByRestrictionType(type));
     }
     const decimals = await Promise.all(restrictionType);
@@ -939,20 +939,20 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
   private checkRestrictionInputParams = (
     startTime: Date,
     allowedTokens: BigNumber,
-    restrictionType: RestrictionTypes,
+    restrictionType: RestrictionType,
     rollingPeriodInDays: number,
   ): void => {
     assert.isFutureDate(startTime, 'Start time must be in the future');
     assert.isBigNumberGreaterThanZero(allowedTokens, 'Allowed Tokens must be greater than 0');
-    if (restrictionType === RestrictionTypes.Percentage) {
+    if (restrictionType === RestrictionType.Percentage) {
       assert.isPercentage('allowed tokens', allowedTokens);
     }
     assert.assert(rollingPeriodInDays <= 365 && rollingPeriodInDays >= 1, 'Invalid number of days in rolling period');
   };
 
-  private decimalsByRestrictionType = async (restrictionType: RestrictionTypes): Promise<BigNumber> => {
+  private decimalsByRestrictionType = async (restrictionType: RestrictionType): Promise<BigNumber> => {
     let decimals = PERCENTAGE_DECIMALS;
-    if (restrictionType === RestrictionTypes.Fixed) {
+    if (restrictionType === RestrictionType.Fixed) {
       decimals = await (await this.securityTokenContract()).decimals.callAsync();
     }
     return decimals;

--- a/src/contract_wrappers/registries/__tests__/feature_registry_wrapper.test.ts
+++ b/src/contract_wrappers/registries/__tests__/feature_registry_wrapper.test.ts
@@ -3,7 +3,7 @@ import { mock, instance, reset, when, verify } from 'ts-mockito';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { FeatureRegistryContract, PolyTokenEvents } from '@polymathnetwork/abi-wrappers';
 import { MockedCallMethod, MockedSendMethod, getMockedPolyResponse } from '../../../test_utils/mocked_methods';
-import { Features } from '../../../types';
+import { Feature } from '../../../types';
 import ContractWrapper from '../../contract_wrapper';
 import FeatureRegistryWrapper from '../feature_registry_wrapper';
 
@@ -36,7 +36,7 @@ describe('FeatureRegistryWrapper', () => {
       // Address expected
       const expectedResult = true;
       // Contract requested
-      const featureName = Features.CustomModulesAllowed.toString();
+      const featureName = Feature.CustomModulesAllowed.toString();
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -57,7 +57,7 @@ describe('FeatureRegistryWrapper', () => {
       // Address expected
       const expectedResult = true;
       // Contract requested
-      const featureName = Features.CustomModulesAllowed.toString();
+      const featureName = Feature.CustomModulesAllowed.toString();
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -78,7 +78,7 @@ describe('FeatureRegistryWrapper', () => {
       // Address expected
       const expectedResult = true;
       // Contract requested
-      const featureName = Features.FreezeMintingAllowed.toString();
+      const featureName = Feature.FreezeMintingAllowed.toString();
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -110,7 +110,7 @@ describe('FeatureRegistryWrapper', () => {
         // Address expected
         const currentFeatureStatus = false;
         // Feature name requested
-        const featureName = Features.CustomModulesAllowed.toString();
+        const featureName = Feature.CustomModulesAllowed.toString();
         // Mocked Get method
         const mockedGetMethod = mock(MockedCallMethod);
         // Stub the get method
@@ -120,7 +120,7 @@ describe('FeatureRegistryWrapper', () => {
 
         // Mocked parameters
         const mockedParams = {
-          nameKey: Features.CustomModulesAllowed,
+          nameKey: Feature.CustomModulesAllowed,
           newStatus: true,
           txData: {},
           safetyFactor: 10,

--- a/src/contract_wrappers/registries/__tests__/module_registry_wrapper.test.ts
+++ b/src/contract_wrappers/registries/__tests__/module_registry_wrapper.test.ts
@@ -8,7 +8,7 @@ import {
   FeatureRegistryContract,
   ModuleFactoryContract,
 } from '@polymathnetwork/abi-wrappers';
-import { Features, ModuleType } from '../../../types';
+import { Feature, ModuleType } from '../../../types';
 import ContractWrapper from '../../contract_wrapper';
 import ModuleRegistryWrapper from '../module_registry_wrapper';
 import ContractFactory from '../../../factories/contractFactory';
@@ -65,7 +65,7 @@ describe('ModuleRegistryWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
 
       // Setup mocked owner from module factory contract
       const moduleFactoryAddress = '0x3333333333333333333333333333333333333333';
@@ -145,7 +145,7 @@ describe('ModuleRegistryWrapper', () => {
       verify(mockedModuleFactoryContract.getTypes).once();
       verify(mockedGetTypesMethod.callAsync()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).once();
       verify(mockedContractOwnerMethod.callAsync()).once();
       verify(mockedContract.owner).once();
       verify(mockedContract.isPaused).once();

--- a/src/contract_wrappers/registries/__tests__/polymath_registry_wrapper.test.ts
+++ b/src/contract_wrappers/registries/__tests__/polymath_registry_wrapper.test.ts
@@ -3,7 +3,7 @@ import { mock, instance, reset, when, verify } from 'ts-mockito';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { PolymathRegistryContract, PolyTokenEvents, PolymathRegistryEvents } from '@polymathnetwork/abi-wrappers';
 import { MockedCallMethod, MockedSendMethod, getMockedPolyResponse } from '../../../test_utils/mocked_methods';
-import { PolymathContracts } from '../../../types';
+import { PolymathContract } from '../../../types';
 import ContractWrapper from '../../contract_wrapper';
 import PolymathRegistryWrapper from '../polymath_registry_wrapper';
 
@@ -59,7 +59,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.PolyToken;
+      const contractName = PolymathContract.PolyToken;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -81,7 +81,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.ModuleRegistry;
+      const contractName = PolymathContract.ModuleRegistry;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -103,7 +103,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.FeatureRegistry;
+      const contractName = PolymathContract.FeatureRegistry;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -125,7 +125,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.SecurityTokenRegistry;
+      const contractName = PolymathContract.SecurityTokenRegistry;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -147,7 +147,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.PolyUsdOracle;
+      const contractName = PolymathContract.PolyUsdOracle;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -169,7 +169,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.EthUsdOracle;
+      const contractName = PolymathContract.EthUsdOracle;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method

--- a/src/contract_wrappers/registries/__tests__/polymath_registry_wrapper.test.ts
+++ b/src/contract_wrappers/registries/__tests__/polymath_registry_wrapper.test.ts
@@ -59,7 +59,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.polyToken;
+      const contractName = PolymathContracts.PolyToken;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -81,7 +81,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.moduleRegistry;
+      const contractName = PolymathContracts.ModuleRegistry;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -103,7 +103,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.featureRegistry;
+      const contractName = PolymathContracts.FeatureRegistry;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -125,7 +125,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.securityTokenRegistry;
+      const contractName = PolymathContracts.SecurityTokenRegistry;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -147,7 +147,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.polyUsdOracle;
+      const contractName = PolymathContracts.PolyUsdOracle;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
@@ -169,7 +169,7 @@ describe('PolyMathRegistryWrapper', () => {
       // Address expected
       const expectedResult = '0x0123456789012345678901234567890123456789';
       // Contract requested
-      const contractName = PolymathContracts.ethUsdOracle;
+      const contractName = PolymathContracts.EthUsdOracle;
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method

--- a/src/contract_wrappers/registries/feature_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/feature_registry_wrapper.ts
@@ -17,7 +17,7 @@ import {
   GetLogsAsyncParams,
   SubscribeAsyncParams,
   EventCallback,
-  Features,
+  Feature,
   Subscribe,
   GetLogs,
 } from '../../types';
@@ -137,7 +137,7 @@ export default class FeatureRegistryWrapper extends ContractWrapper {
    * @return bool
    */
   public getCustomModulesAllowedStatus = async () => {
-    return (await this.contract).getFeatureStatus.callAsync(Features.CustomModulesAllowed);
+    return (await this.contract).getFeatureStatus.callAsync(Feature.CustomModulesAllowed);
   };
 
   /**
@@ -145,7 +145,7 @@ export default class FeatureRegistryWrapper extends ContractWrapper {
    * @return bool
    */
   public getFreezeMintingAllowedStatus = async () => {
-    return (await this.contract).getFeatureStatus.callAsync(Features.FreezeMintingAllowed);
+    return (await this.contract).getFeatureStatus.callAsync(Feature.FreezeMintingAllowed);
   };
 
   /**

--- a/src/contract_wrappers/registries/module_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/module_registry_wrapper.ts
@@ -23,7 +23,7 @@ import ContractWrapper from '../contract_wrapper';
 import ContractFactory from '../../factories/contractFactory';
 import {
   EventCallback,
-  Features,
+  Feature,
   GetLogs,
   GetLogsAsyncParams,
   ModuleType,
@@ -208,7 +208,7 @@ export default class ModuleRegistryWrapper extends ContractWrapper {
     await this.checkModuleNotRegistered(params.moduleFactory);
     const callerAddress = await this.getCallerAddress(params.txData);
     const owner = await this.owner();
-    if ((await this.featureRegistryContract()).getFeatureStatus.callAsync(Features.CustomModulesAllowed)) {
+    if ((await this.featureRegistryContract()).getFeatureStatus.callAsync(Feature.CustomModulesAllowed)) {
       const factoryOwner = await (await this.moduleFactoryContract(params.moduleFactory)).owner.callAsync();
       assert.assert(
         functionsUtils.checksumAddressComparision(callerAddress, owner) ||

--- a/src/contract_wrappers/registries/polymath_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/polymath_registry_wrapper.ts
@@ -17,7 +17,7 @@ import {
   GetLogsAsyncParams,
   SubscribeAsyncParams,
   EventCallback,
-  PolymathContracts,
+  PolymathContract,
   GetLogs,
   Subscribe,
 } from '../../types';
@@ -117,7 +117,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getPolyTokenAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.PolyToken);
+    return this.getAddressInternal(PolymathContract.PolyToken);
   };
 
   /**
@@ -125,7 +125,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getModuleRegistryAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.ModuleRegistry);
+    return this.getAddressInternal(PolymathContract.ModuleRegistry);
   };
 
   /**
@@ -133,7 +133,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getFeatureRegistryAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.FeatureRegistry);
+    return this.getAddressInternal(PolymathContract.FeatureRegistry);
   };
 
   /**
@@ -141,7 +141,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getSecurityTokenRegistryAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.SecurityTokenRegistry);
+    return this.getAddressInternal(PolymathContract.SecurityTokenRegistry);
   };
 
   /**
@@ -149,7 +149,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getPolyUsdOracleAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.PolyUsdOracle);
+    return this.getAddressInternal(PolymathContract.PolyUsdOracle);
   };
 
   /**
@@ -157,7 +157,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getEthUsdOracleAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.EthUsdOracle);
+    return this.getAddressInternal(PolymathContract.EthUsdOracle);
   };
 
   /**

--- a/src/contract_wrappers/registries/polymath_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/polymath_registry_wrapper.ts
@@ -117,7 +117,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getPolyTokenAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.polyToken);
+    return this.getAddressInternal(PolymathContracts.PolyToken);
   };
 
   /**
@@ -125,7 +125,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getModuleRegistryAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.moduleRegistry);
+    return this.getAddressInternal(PolymathContracts.ModuleRegistry);
   };
 
   /**
@@ -133,7 +133,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getFeatureRegistryAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.featureRegistry);
+    return this.getAddressInternal(PolymathContracts.FeatureRegistry);
   };
 
   /**
@@ -141,7 +141,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getSecurityTokenRegistryAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.securityTokenRegistry);
+    return this.getAddressInternal(PolymathContracts.SecurityTokenRegistry);
   };
 
   /**
@@ -149,7 +149,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getPolyUsdOracleAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.polyUsdOracle);
+    return this.getAddressInternal(PolymathContracts.PolyUsdOracle);
   };
 
   /**
@@ -157,7 +157,7 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
    * @return address string
    */
   public getEthUsdOracleAddress = async () => {
-    return this.getAddressInternal(PolymathContracts.ethUsdOracle);
+    return this.getAddressInternal(PolymathContracts.EthUsdOracle);
   };
 
   /**

--- a/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
+++ b/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
@@ -20,7 +20,7 @@ import {
   ModuleRegistryContract,
 } from '@polymathnetwork/abi-wrappers';
 import ERC20TokenWrapper from '../erc20_wrapper';
-import { ModuleType, ModuleNames, Features, FundRaiseType, PERCENTAGE_DECIMALS, FULL_DECIMALS } from '../../../types';
+import { ModuleType, ModuleName, Feature, FundRaiseType, PERCENTAGE_DECIMALS, FULL_DECIMALS } from '../../../types';
 import SecurityTokenWrapper from '../security_token_wrapper';
 import ContractFactory from '../../../factories/contractFactory';
 import {
@@ -341,7 +341,7 @@ describe('SecurityTokenWrapper', () => {
         '0x0123456789012345678901234567890123456788',
       ];
       const mockedParams = {
-        moduleName: ModuleNames.GeneralPermissionManager,
+        moduleName: ModuleName.GeneralPermissionManager,
       };
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
@@ -1627,7 +1627,7 @@ describe('SecurityTokenWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.FreezeMintingAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.FreezeMintingAllowed)).thenResolve(currentFeatureStatus);
 
       // Real call
       const result = await target.freezeMinting(mockedParams);
@@ -1643,7 +1643,7 @@ describe('SecurityTokenWrapper', () => {
       verify(mockedFrozenMethod.callAsync()).once();
       verify(mockedContractFactory.getFeatureRegistryContract()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.FreezeMintingAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.FreezeMintingAllowed)).once();
       verify(mockedWrapper.getAvailableAddressesAsync()).once();
     });
   });
@@ -2399,7 +2399,7 @@ describe('SecurityTokenWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
 
       // Setup mocked contractFactory owner
       const mockedModuleFactoryOwnerMethod = mock(MockedCallMethod);
@@ -2459,7 +2459,7 @@ describe('SecurityTokenWrapper', () => {
         maxHolderCount: 10,
       };
       const mockedCtmParams = {
-        moduleName: ModuleNames.CountTransferManager,
+        moduleName: ModuleName.CountTransferManager,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -2483,7 +2483,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const ctmResult = await target.addModule({
-        moduleName: ModuleNames.CountTransferManager,
+        moduleName: ModuleName.CountTransferManager,
         address: mockedCtmParams.address,
         maxCost: mockedCtmParams.maxCost,
         budget: mockedCtmParams.budget,
@@ -2519,7 +2519,7 @@ describe('SecurityTokenWrapper', () => {
       verify(mockedModuleMethod.callAsync(ADDRESS)).once();
       verify(mockedContractFactory.getFeatureRegistryContract()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).once();
       verify(mockedModuleFactoryContract.owner).once();
       verify(mockedModuleFactoryOwnerMethod.callAsync()).once();
       verify(mockedContractFactory.getModuleRegistryContract()).once();
@@ -2582,7 +2582,7 @@ describe('SecurityTokenWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
 
       // Setup mocked contractFactory owner
       const mockedModuleFactoryOwnerMethod = mock(MockedCallMethod);
@@ -2642,7 +2642,7 @@ describe('SecurityTokenWrapper', () => {
         allowPrimaryIssuance: true,
       };
       const mockedPtmParams = {
-        moduleName: ModuleNames.PercentageTransferManager,
+        moduleName: ModuleName.PercentageTransferManager,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -2669,7 +2669,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const ptmResult = await target.addModule({
-        moduleName: ModuleNames.PercentageTransferManager,
+        moduleName: ModuleName.PercentageTransferManager,
         address: mockedPtmParams.address,
         maxCost: mockedPtmParams.maxCost,
         budget: mockedPtmParams.budget,
@@ -2706,7 +2706,7 @@ describe('SecurityTokenWrapper', () => {
       verify(mockedModuleMethod.callAsync(ADDRESS)).once();
       verify(mockedContractFactory.getFeatureRegistryContract()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).once();
       verify(mockedModuleFactoryContract.owner).once();
       verify(mockedModuleFactoryOwnerMethod.callAsync()).once();
       verify(mockedContractFactory.getModuleRegistryContract()).once();
@@ -2760,7 +2760,7 @@ describe('SecurityTokenWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
 
       // Setup mocked contractFactory owner
       const mockedModuleFactoryOwnerMethod = mock(MockedCallMethod);
@@ -2833,7 +2833,7 @@ describe('SecurityTokenWrapper', () => {
         fundsReceiver: '0x2222222222222222222222222222222222222222',
       };
       const mockedCappedParams = {
-        moduleName: ModuleNames.CappedSTO,
+        moduleName: ModuleName.CappedSTO,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -2864,7 +2864,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const cappedResult = await target.addModule({
-        moduleName: ModuleNames.CappedSTO,
+        moduleName: ModuleName.CappedSTO,
         address: mockedCappedParams.address,
         maxCost: mockedCappedParams.maxCost,
         budget: mockedCappedParams.budget,
@@ -2905,7 +2905,7 @@ describe('SecurityTokenWrapper', () => {
       verify(mockedModuleMethod.callAsync(ADDRESS)).once();
       verify(mockedContractFactory.getFeatureRegistryContract()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).once();
       verify(mockedModuleFactoryContract.owner).once();
       verify(mockedModuleFactoryOwnerMethod.callAsync()).once();
       verify(mockedContractFactory.getModuleRegistryContract()).once();
@@ -2968,7 +2968,7 @@ describe('SecurityTokenWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
 
       // Setup mocked contractFactory owner
       const mockedModuleFactoryOwnerMethod = mock(MockedCallMethod);
@@ -3038,7 +3038,7 @@ describe('SecurityTokenWrapper', () => {
         usdTokens: ['0x1111111111111111111111111111111111111111', '0x2222222222222222222222222222222222222222'],
       };
       const mockedUsdTieredStoParams = {
-        moduleName: ModuleNames.UsdTieredSTO,
+        moduleName: ModuleName.UsdTieredSTO,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -3083,7 +3083,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const usdTieredStoResult = await target.addModule({
-        moduleName: ModuleNames.UsdTieredSTO,
+        moduleName: ModuleName.UsdTieredSTO,
         address: mockedUsdTieredStoParams.address,
         maxCost: mockedUsdTieredStoParams.maxCost,
         budget: mockedUsdTieredStoParams.budget,
@@ -3130,7 +3130,7 @@ describe('SecurityTokenWrapper', () => {
       verify(mockedModuleMethod.callAsync(ADDRESS)).once();
       verify(mockedContractFactory.getFeatureRegistryContract()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).once();
       verify(mockedModuleFactoryContract.owner).once();
       verify(mockedModuleFactoryOwnerMethod.callAsync()).once();
       verify(mockedContractFactory.getModuleRegistryContract()).once();
@@ -3193,7 +3193,7 @@ describe('SecurityTokenWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
 
       // Setup mocked contractFactory owner
       const mockedModuleFactoryOwnerMethod = mock(MockedCallMethod);
@@ -3252,7 +3252,7 @@ describe('SecurityTokenWrapper', () => {
         wallet: '0x1111111111111111111111111111111111111111',
       };
       const mockedErc20DividendParams = {
-        moduleName: ModuleNames.ERC20DividendCheckpoint,
+        moduleName: ModuleName.ERC20DividendCheckpoint,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -3276,7 +3276,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const erc20DividendResult = await target.addModule({
-        moduleName: ModuleNames.ERC20DividendCheckpoint,
+        moduleName: ModuleName.ERC20DividendCheckpoint,
         address: mockedErc20DividendParams.address,
         maxCost: mockedErc20DividendParams.maxCost,
         budget: mockedErc20DividendParams.budget,
@@ -3312,7 +3312,7 @@ describe('SecurityTokenWrapper', () => {
       verify(mockedModuleMethod.callAsync(ADDRESS)).once();
       verify(mockedContractFactory.getFeatureRegistryContract()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).once();
       verify(mockedModuleFactoryContract.owner).once();
       verify(mockedModuleFactoryOwnerMethod.callAsync()).once();
       verify(mockedContractFactory.getModuleRegistryContract()).once();
@@ -3375,7 +3375,7 @@ describe('SecurityTokenWrapper', () => {
       const mockedGetFeatureStatusMethod = mock(MockedCallMethod);
       const currentFeatureStatus = true;
       when(mockedFeatureRegistryContract.getFeatureStatus).thenReturn(instance(mockedGetFeatureStatusMethod));
-      when(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
+      when(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).thenResolve(currentFeatureStatus);
 
       // Setup mocked contractFactory owner
       const mockedModuleFactoryOwnerMethod = mock(MockedCallMethod);
@@ -3434,7 +3434,7 @@ describe('SecurityTokenWrapper', () => {
         wallet: '0x1111111111111111111111111111111111111111',
       };
       const mockedEtherDividendParams = {
-        moduleName: ModuleNames.EtherDividendCheckpoint,
+        moduleName: ModuleName.EtherDividendCheckpoint,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -3458,7 +3458,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const etherDividendResult = await target.addModule({
-        moduleName: ModuleNames.EtherDividendCheckpoint,
+        moduleName: ModuleName.EtherDividendCheckpoint,
         address: mockedEtherDividendParams.address,
         maxCost: mockedEtherDividendParams.maxCost,
         budget: mockedEtherDividendParams.budget,
@@ -3494,7 +3494,7 @@ describe('SecurityTokenWrapper', () => {
       verify(mockedModuleMethod.callAsync(ADDRESS)).once();
       verify(mockedContractFactory.getFeatureRegistryContract()).once();
       verify(mockedFeatureRegistryContract.getFeatureStatus).once();
-      verify(mockedGetFeatureStatusMethod.callAsync(Features.CustomModulesAllowed)).once();
+      verify(mockedGetFeatureStatusMethod.callAsync(Feature.CustomModulesAllowed)).once();
       verify(mockedModuleFactoryContract.owner).once();
       verify(mockedModuleFactoryOwnerMethod.callAsync()).once();
       verify(mockedContractFactory.getModuleRegistryContract()).once();

--- a/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
+++ b/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
@@ -20,7 +20,7 @@ import {
   ModuleRegistryContract,
 } from '@polymathnetwork/abi-wrappers';
 import ERC20TokenWrapper from '../erc20_wrapper';
-import { ModuleType, ModuleName, Features, FundRaiseType, PERCENTAGE_DECIMALS, FULL_DECIMALS } from '../../../types';
+import { ModuleType, ModuleNames, Features, FundRaiseType, PERCENTAGE_DECIMALS, FULL_DECIMALS } from '../../../types';
 import SecurityTokenWrapper from '../security_token_wrapper';
 import ContractFactory from '../../../factories/contractFactory';
 import {
@@ -341,7 +341,7 @@ describe('SecurityTokenWrapper', () => {
         '0x0123456789012345678901234567890123456788',
       ];
       const mockedParams = {
-        moduleName: ModuleName.generalPermissionManager,
+        moduleName: ModuleNames.GeneralPermissionManager,
       };
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
@@ -2459,7 +2459,7 @@ describe('SecurityTokenWrapper', () => {
         maxHolderCount: 10,
       };
       const mockedCtmParams = {
-        moduleName: ModuleName.countTransferManager,
+        moduleName: ModuleNames.CountTransferManager,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -2483,7 +2483,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const ctmResult = await target.addModule({
-        moduleName: ModuleName.countTransferManager,
+        moduleName: ModuleNames.CountTransferManager,
         address: mockedCtmParams.address,
         maxCost: mockedCtmParams.maxCost,
         budget: mockedCtmParams.budget,
@@ -2642,7 +2642,7 @@ describe('SecurityTokenWrapper', () => {
         allowPrimaryIssuance: true,
       };
       const mockedPtmParams = {
-        moduleName: ModuleName.percentageTransferManager,
+        moduleName: ModuleNames.PercentageTransferManager,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -2669,7 +2669,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const ptmResult = await target.addModule({
-        moduleName: ModuleName.percentageTransferManager,
+        moduleName: ModuleNames.PercentageTransferManager,
         address: mockedPtmParams.address,
         maxCost: mockedPtmParams.maxCost,
         budget: mockedPtmParams.budget,
@@ -2833,7 +2833,7 @@ describe('SecurityTokenWrapper', () => {
         fundsReceiver: '0x2222222222222222222222222222222222222222',
       };
       const mockedCappedParams = {
-        moduleName: ModuleName.cappedSTO,
+        moduleName: ModuleNames.CappedSTO,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -2864,7 +2864,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const cappedResult = await target.addModule({
-        moduleName: ModuleName.cappedSTO,
+        moduleName: ModuleNames.CappedSTO,
         address: mockedCappedParams.address,
         maxCost: mockedCappedParams.maxCost,
         budget: mockedCappedParams.budget,
@@ -3038,7 +3038,7 @@ describe('SecurityTokenWrapper', () => {
         usdTokens: ['0x1111111111111111111111111111111111111111', '0x2222222222222222222222222222222222222222'],
       };
       const mockedUsdTieredStoParams = {
-        moduleName: ModuleName.usdTieredSTO,
+        moduleName: ModuleNames.UsdTieredSTO,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -3083,7 +3083,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const usdTieredStoResult = await target.addModule({
-        moduleName: ModuleName.usdTieredSTO,
+        moduleName: ModuleNames.UsdTieredSTO,
         address: mockedUsdTieredStoParams.address,
         maxCost: mockedUsdTieredStoParams.maxCost,
         budget: mockedUsdTieredStoParams.budget,
@@ -3252,7 +3252,7 @@ describe('SecurityTokenWrapper', () => {
         wallet: '0x1111111111111111111111111111111111111111',
       };
       const mockedErc20DividendParams = {
-        moduleName: ModuleName.erc20DividendCheckpoint,
+        moduleName: ModuleNames.ERC20DividendCheckpoint,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -3276,7 +3276,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const erc20DividendResult = await target.addModule({
-        moduleName: ModuleName.erc20DividendCheckpoint,
+        moduleName: ModuleNames.ERC20DividendCheckpoint,
         address: mockedErc20DividendParams.address,
         maxCost: mockedErc20DividendParams.maxCost,
         budget: mockedErc20DividendParams.budget,
@@ -3434,7 +3434,7 @@ describe('SecurityTokenWrapper', () => {
         wallet: '0x1111111111111111111111111111111111111111',
       };
       const mockedEtherDividendParams = {
-        moduleName: ModuleName.etherDividendCheckpoint,
+        moduleName: ModuleNames.EtherDividendCheckpoint,
         address: ADDRESS,
         maxCost: new BigNumber(1),
         budget: new BigNumber(1),
@@ -3458,7 +3458,7 @@ describe('SecurityTokenWrapper', () => {
       ).thenResolve(expectedResult);
 
       const etherDividendResult = await target.addModule({
-        moduleName: ModuleName.etherDividendCheckpoint,
+        moduleName: ModuleNames.EtherDividendCheckpoint,
         address: mockedEtherDividendParams.address,
         maxCost: mockedEtherDividendParams.maxCost,
         budget: mockedEtherDividendParams.budget,

--- a/src/contract_wrappers/tokens/security_token_wrapper.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper.ts
@@ -54,7 +54,7 @@ import {
   Subscribe,
   ModuleType,
   FundRaiseType,
-  ModuleName,
+  ModuleNames,
   Features,
   PERCENTAGE_DECIMALS,
   FULL_DECIMALS,
@@ -351,7 +351,7 @@ interface TransferOwnershipParams extends TxParams {
 }
 
 interface ModuleNameParams {
-  moduleName: ModuleName;
+  moduleName: ModuleNames;
 }
 
 interface WithdrawERC20Params extends TxParams {
@@ -451,7 +451,7 @@ interface ForceBurnParams extends TxParams {
 }
 
 interface AddModuleParams extends TxParams {
-  moduleName: ModuleName;
+  moduleName: ModuleNames;
   address: string;
   maxCost?: BigNumber;
   budget?: BigNumber;
@@ -465,35 +465,35 @@ interface AddModuleParams extends TxParams {
 
 interface AddNoDataModuleParams extends AddModuleParams {
   moduleName:
-    | ModuleName.generalPermissionManager
-    | ModuleName.generalTransferManager
-    | ModuleName.manualApprovalTransferManager
-    | ModuleName.volumeRestrictionTM;
+    | ModuleNames.GeneralPermissionManager
+    | ModuleNames.GeneralTransferManager
+    | ModuleNames.ManualApprovalTransferManager
+    | ModuleNames.VolumeRestrictionTM;
   data?: undefined;
 }
 
 interface AddCountTransferManagerParams extends AddModuleParams {
-  moduleName: ModuleName.countTransferManager;
+  moduleName: ModuleNames.CountTransferManager;
   data: CountTransferManagerData;
 }
 
 interface AddPercentageTransferManagerParams extends AddModuleParams {
-  moduleName: ModuleName.percentageTransferManager;
+  moduleName: ModuleNames.PercentageTransferManager;
   data: PercentageTransferManagerData;
 }
 
 interface AddDividendCheckpointParams extends AddModuleParams {
-  moduleName: ModuleName.etherDividendCheckpoint | ModuleName.erc20DividendCheckpoint;
+  moduleName: ModuleNames.EtherDividendCheckpoint | ModuleNames.ERC20DividendCheckpoint;
   data: DividendCheckpointData;
 }
 
 interface AddCappedSTOParams extends AddModuleParams {
-  moduleName: ModuleName.cappedSTO;
+  moduleName: ModuleNames.CappedSTO;
   data: CappedSTOData;
 }
 
 interface AddUSDTieredSTOParams extends AddModuleParams {
-  moduleName: ModuleName.usdTieredSTO;
+  moduleName: ModuleNames.UsdTieredSTO;
   data: USDTieredSTOData;
 }
 
@@ -1032,11 +1032,11 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
     let iface: ethers.utils.Interface;
     let data: string;
     switch (params.moduleName) {
-      case ModuleName.countTransferManager:
+      case ModuleNames.CountTransferManager:
         iface = new ethers.utils.Interface(CountTransferManager.abi);
         data = iface.functions.configure.encode([(params.data as CountTransferManagerData).maxHolderCount]);
         break;
-      case ModuleName.percentageTransferManager:
+      case ModuleNames.PercentageTransferManager:
         iface = new ethers.utils.Interface(PercentageTransferManager.abi);
         data = iface.functions.configure.encode([
           valueToWei(
@@ -1046,7 +1046,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
           (params.data as PercentageTransferManagerData).allowPrimaryIssuance,
         ]);
         break;
-      case ModuleName.cappedSTO:
+      case ModuleNames.CappedSTO:
         await this.cappedSTOAssertions(params.data as CappedSTOData);
         iface = new ethers.utils.Interface(CappedSTO.abi);
         data = iface.functions.configure.encode([
@@ -1058,7 +1058,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
           (params.data as CappedSTOData).fundsReceiver,
         ]);
         break;
-      case ModuleName.usdTieredSTO:
+      case ModuleNames.UsdTieredSTO:
         await this.usdTieredSTOAssertions(params.data as USDTieredSTOData);
         iface = new ethers.utils.Interface(USDTieredSTO.abi);
         data = iface.functions.configure.encode([
@@ -1084,12 +1084,12 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
           (params.data as USDTieredSTOData).usdTokens,
         ]);
         break;
-      case ModuleName.erc20DividendCheckpoint:
+      case ModuleNames.ERC20DividendCheckpoint:
         assert.isNonZeroETHAddressHex('Wallet', (params.data as DividendCheckpointData).wallet);
         iface = new ethers.utils.Interface(ERC20DividendCheckpoint.abi);
         data = iface.functions.configure.encode([(params.data as DividendCheckpointData).wallet]);
         break;
-      case ModuleName.etherDividendCheckpoint:
+      case ModuleNames.EtherDividendCheckpoint:
         assert.isNonZeroETHAddressHex('Wallet', (params.data as DividendCheckpointData).wallet);
         iface = new ethers.utils.Interface(EtherDividendCheckpoint.abi);
         data = iface.functions.configure.encode([(params.data as DividendCheckpointData).wallet]);

--- a/src/contract_wrappers/tokens/security_token_wrapper.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper.ts
@@ -54,8 +54,8 @@ import {
   Subscribe,
   ModuleType,
   FundRaiseType,
-  ModuleNames,
-  Features,
+  ModuleName,
+  Feature,
   PERCENTAGE_DECIMALS,
   FULL_DECIMALS,
 } from '../../types';
@@ -351,7 +351,7 @@ interface TransferOwnershipParams extends TxParams {
 }
 
 interface ModuleNameParams {
-  moduleName: ModuleNames;
+  moduleName: ModuleName;
 }
 
 interface WithdrawERC20Params extends TxParams {
@@ -451,7 +451,7 @@ interface ForceBurnParams extends TxParams {
 }
 
 interface AddModuleParams extends TxParams {
-  moduleName: ModuleNames;
+  moduleName: ModuleName;
   address: string;
   maxCost?: BigNumber;
   budget?: BigNumber;
@@ -465,35 +465,35 @@ interface AddModuleParams extends TxParams {
 
 interface AddNoDataModuleParams extends AddModuleParams {
   moduleName:
-    | ModuleNames.GeneralPermissionManager
-    | ModuleNames.GeneralTransferManager
-    | ModuleNames.ManualApprovalTransferManager
-    | ModuleNames.VolumeRestrictionTM;
+    | ModuleName.GeneralPermissionManager
+    | ModuleName.GeneralTransferManager
+    | ModuleName.ManualApprovalTransferManager
+    | ModuleName.VolumeRestrictionTM;
   data?: undefined;
 }
 
 interface AddCountTransferManagerParams extends AddModuleParams {
-  moduleName: ModuleNames.CountTransferManager;
+  moduleName: ModuleName.CountTransferManager;
   data: CountTransferManagerData;
 }
 
 interface AddPercentageTransferManagerParams extends AddModuleParams {
-  moduleName: ModuleNames.PercentageTransferManager;
+  moduleName: ModuleName.PercentageTransferManager;
   data: PercentageTransferManagerData;
 }
 
 interface AddDividendCheckpointParams extends AddModuleParams {
-  moduleName: ModuleNames.EtherDividendCheckpoint | ModuleNames.ERC20DividendCheckpoint;
+  moduleName: ModuleName.EtherDividendCheckpoint | ModuleName.ERC20DividendCheckpoint;
   data: DividendCheckpointData;
 }
 
 interface AddCappedSTOParams extends AddModuleParams {
-  moduleName: ModuleNames.CappedSTO;
+  moduleName: ModuleName.CappedSTO;
   data: CappedSTOData;
 }
 
 interface AddUSDTieredSTOParams extends AddModuleParams {
-  moduleName: ModuleNames.UsdTieredSTO;
+  moduleName: ModuleName.UsdTieredSTO;
   data: USDTieredSTOData;
 }
 
@@ -838,7 +838,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
 
   public freezeMinting = async (params: TxParams) => {
     assert.assert(
-      await (await this.featureRegistryContract()).getFeatureStatus.callAsync(Features.FreezeMintingAllowed),
+      await (await this.featureRegistryContract()).getFeatureStatus.callAsync(Feature.FreezeMintingAllowed),
       'FreezeMintingAllowed Feature Status not enabled',
     );
     assert.assert(!(await this.mintingFrozen()), 'Minting already frozen');
@@ -1032,11 +1032,11 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
     let iface: ethers.utils.Interface;
     let data: string;
     switch (params.moduleName) {
-      case ModuleNames.CountTransferManager:
+      case ModuleName.CountTransferManager:
         iface = new ethers.utils.Interface(CountTransferManager.abi);
         data = iface.functions.configure.encode([(params.data as CountTransferManagerData).maxHolderCount]);
         break;
-      case ModuleNames.PercentageTransferManager:
+      case ModuleName.PercentageTransferManager:
         iface = new ethers.utils.Interface(PercentageTransferManager.abi);
         data = iface.functions.configure.encode([
           valueToWei(
@@ -1046,7 +1046,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
           (params.data as PercentageTransferManagerData).allowPrimaryIssuance,
         ]);
         break;
-      case ModuleNames.CappedSTO:
+      case ModuleName.CappedSTO:
         await this.cappedSTOAssertions(params.data as CappedSTOData);
         iface = new ethers.utils.Interface(CappedSTO.abi);
         data = iface.functions.configure.encode([
@@ -1058,7 +1058,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
           (params.data as CappedSTOData).fundsReceiver,
         ]);
         break;
-      case ModuleNames.UsdTieredSTO:
+      case ModuleName.UsdTieredSTO:
         await this.usdTieredSTOAssertions(params.data as USDTieredSTOData);
         iface = new ethers.utils.Interface(USDTieredSTO.abi);
         data = iface.functions.configure.encode([
@@ -1084,12 +1084,12 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
           (params.data as USDTieredSTOData).usdTokens,
         ]);
         break;
-      case ModuleNames.ERC20DividendCheckpoint:
+      case ModuleName.ERC20DividendCheckpoint:
         assert.isNonZeroETHAddressHex('Wallet', (params.data as DividendCheckpointData).wallet);
         iface = new ethers.utils.Interface(ERC20DividendCheckpoint.abi);
         data = iface.functions.configure.encode([(params.data as DividendCheckpointData).wallet]);
         break;
-      case ModuleNames.EtherDividendCheckpoint:
+      case ModuleName.EtherDividendCheckpoint:
         assert.isNonZeroETHAddressHex('Wallet', (params.data as DividendCheckpointData).wallet);
         iface = new ethers.utils.Interface(EtherDividendCheckpoint.abi);
         data = iface.functions.configure.encode([(params.data as DividendCheckpointData).wallet]);
@@ -1245,7 +1245,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
   };
 
   private checkUseModuleVerified = async (address: string) => {
-    if (await (await this.featureRegistryContract()).getFeatureStatus.callAsync(Features.CustomModulesAllowed)) {
+    if (await (await this.featureRegistryContract()).getFeatureStatus.callAsync(Feature.CustomModulesAllowed)) {
       const isOwner = (await (await this.moduleFactoryContract(address)).owner.callAsync()) === (await this.owner());
       assert.assert(
         (await this.checkForRegisteredModule(address)) || isOwner,

--- a/src/factories/contractFactory.ts
+++ b/src/factories/contractFactory.ts
@@ -130,7 +130,7 @@ export default class ContractFactory {
   public async getPolyTokenFaucetContract(): Promise<PolyTokenFaucetContract> {
     return new PolyTokenFaucetContract(
       PolyTokenFaucet.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.polyToken),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.PolyToken),
       this.provider,
       this.contractDefaults,
     );
@@ -139,7 +139,7 @@ export default class ContractFactory {
   public async getPolyTokenContract(): Promise<PolyTokenContract> {
     return new PolyTokenContract(
       PolyToken.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.polyToken),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.PolyToken),
       this.provider,
       this.contractDefaults,
     );
@@ -224,7 +224,7 @@ export default class ContractFactory {
   public async getFeatureRegistryContract(): Promise<FeatureRegistryContract> {
     return new FeatureRegistryContract(
       FeatureRegistry.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.featureRegistry),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.FeatureRegistry),
       this.provider,
       this.contractDefaults,
     );
@@ -233,7 +233,7 @@ export default class ContractFactory {
   public async getModuleRegistryContract(): Promise<ModuleRegistryContract> {
     return new ModuleRegistryContract(
       ModuleRegistry.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.moduleRegistry),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.ModuleRegistry),
       this.provider,
       this.contractDefaults,
     );
@@ -242,7 +242,7 @@ export default class ContractFactory {
   public async getSecurityTokenRegistryContract(): Promise<SecurityTokenRegistryContract> {
     return new SecurityTokenRegistryContract(
       SecurityTokenRegistry.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.securityTokenRegistry),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.SecurityTokenRegistry),
       this.provider,
       this.contractDefaults,
     );

--- a/src/factories/contractFactory.ts
+++ b/src/factories/contractFactory.ts
@@ -49,7 +49,7 @@ import {
   PolymathRegistry,
 } from '@polymathnetwork/contract-artifacts';
 import { Web3Wrapper } from '@0x/web3-wrapper';
-import { PolymathContracts, NetworkId } from '../types';
+import { PolymathContract, NetworkId } from '../types';
 import assert from '../utils/assert';
 import getDefaultContractAddresses from '../utils/addresses';
 
@@ -130,7 +130,7 @@ export default class ContractFactory {
   public async getPolyTokenFaucetContract(): Promise<PolyTokenFaucetContract> {
     return new PolyTokenFaucetContract(
       PolyTokenFaucet.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.PolyToken),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContract.PolyToken),
       this.provider,
       this.contractDefaults,
     );
@@ -139,7 +139,7 @@ export default class ContractFactory {
   public async getPolyTokenContract(): Promise<PolyTokenContract> {
     return new PolyTokenContract(
       PolyToken.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.PolyToken),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContract.PolyToken),
       this.provider,
       this.contractDefaults,
     );
@@ -224,7 +224,7 @@ export default class ContractFactory {
   public async getFeatureRegistryContract(): Promise<FeatureRegistryContract> {
     return new FeatureRegistryContract(
       FeatureRegistry.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.FeatureRegistry),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContract.FeatureRegistry),
       this.provider,
       this.contractDefaults,
     );
@@ -233,7 +233,7 @@ export default class ContractFactory {
   public async getModuleRegistryContract(): Promise<ModuleRegistryContract> {
     return new ModuleRegistryContract(
       ModuleRegistry.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.ModuleRegistry),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContract.ModuleRegistry),
       this.provider,
       this.contractDefaults,
     );
@@ -242,7 +242,7 @@ export default class ContractFactory {
   public async getSecurityTokenRegistryContract(): Promise<SecurityTokenRegistryContract> {
     return new SecurityTokenRegistryContract(
       SecurityTokenRegistry.abi,
-      await (await this.polymathRegistry).getAddress.callAsync(PolymathContracts.SecurityTokenRegistry),
+      await (await this.polymathRegistry).getAddress.callAsync(PolymathContract.SecurityTokenRegistry),
       this.provider,
       this.contractDefaults,
     );

--- a/src/factories/moduleWrapperFactory.ts
+++ b/src/factories/moduleWrapperFactory.ts
@@ -11,51 +11,51 @@ import GeneralTransferManagerWrapper from '../contract_wrappers/modules/transfer
 import GeneralPermissionManagerWrapper from '../contract_wrappers/modules/permission_manager/general_permission_manager_wrapper';
 import ContractFactory from './contractFactory';
 import assert from '../utils/assert';
-import { ModuleName } from '../types';
+import { ModuleNames } from '../types';
 
 interface GetModuleParams {
   address: string;
-  name: ModuleName;
+  name: ModuleNames;
 }
 
 interface GetGeneralPermissionManager extends GetModuleParams {
-  name: ModuleName.generalPermissionManager;
+  name: ModuleNames.GeneralPermissionManager;
 }
 
 interface GetCountTransferManager extends GetModuleParams {
-  name: ModuleName.countTransferManager;
+  name: ModuleNames.CountTransferManager;
 }
 
 interface GetGeneralTransferManager extends GetModuleParams {
-  name: ModuleName.generalTransferManager;
+  name: ModuleNames.GeneralTransferManager;
 }
 
 interface GetManualApprovalTransferManager extends GetModuleParams {
-  name: ModuleName.manualApprovalTransferManager;
+  name: ModuleNames.ManualApprovalTransferManager;
 }
 
 interface GetPercentageTransferManager extends GetModuleParams {
-  name: ModuleName.percentageTransferManager;
+  name: ModuleNames.PercentageTransferManager;
 }
 
 interface GetVolumeRestrictionTransferManager extends GetModuleParams {
-  name: ModuleName.volumeRestrictionTM;
+  name: ModuleNames.VolumeRestrictionTM;
 }
 
 interface GetCappedSTO extends GetModuleParams {
-  name: ModuleName.cappedSTO;
+  name: ModuleNames.CappedSTO;
 }
 
 interface GetUSDTieredSTO extends GetModuleParams {
-  name: ModuleName.usdTieredSTO;
+  name: ModuleNames.UsdTieredSTO;
 }
 
 interface GetERC20DividendCheckpoint extends GetModuleParams {
-  name: ModuleName.erc20DividendCheckpoint;
+  name: ModuleNames.ERC20DividendCheckpoint;
 }
 
 interface GetEtherDividendCheckpoint extends GetModuleParams {
-  name: ModuleName.etherDividendCheckpoint;
+  name: ModuleNames.EtherDividendCheckpoint;
 }
 
 interface GetModuleInstance {
@@ -89,64 +89,64 @@ export default class ModuleWrapperFactory {
     assert.isETHAddressHex('address', params.address);
     switch (params.name) {
       // Permission
-      case ModuleName.generalPermissionManager:
+      case ModuleNames.GeneralPermissionManager:
         return new GeneralPermissionManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getGeneralPermissionManagerContract(params.address),
           this.contractFactory,
         );
       // TMs
-      case ModuleName.countTransferManager:
+      case ModuleNames.CountTransferManager:
         return new CountTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getCountTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleName.generalTransferManager:
+      case ModuleNames.GeneralTransferManager:
         return new GeneralTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getGeneralTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleName.manualApprovalTransferManager:
+      case ModuleNames.ManualApprovalTransferManager:
         return new ManualApprovalTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getManualApprovalTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleName.percentageTransferManager:
+      case ModuleNames.PercentageTransferManager:
         return new PercentageTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getPercentageTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleName.volumeRestrictionTM:
+      case ModuleNames.VolumeRestrictionTM:
         return new VolumeRestrictionTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getVolumeRestrictionTMContract(params.address),
           this.contractFactory,
         );
       // STOs
-      case ModuleName.cappedSTO:
+      case ModuleNames.CappedSTO:
         return new CappedSTOWrapper(
           this.web3Wrapper,
           this.contractFactory.getCappedSTOContract(params.address),
           this.contractFactory,
         );
-      case ModuleName.usdTieredSTO:
+      case ModuleNames.UsdTieredSTO:
         return new USDTieredSTOWrapper(
           this.web3Wrapper,
           this.contractFactory.getUSDTieredSTOContract(params.address),
           this.contractFactory,
         );
       // Checkpoint
-      case ModuleName.erc20DividendCheckpoint:
+      case ModuleNames.ERC20DividendCheckpoint:
         return new ERC20DividendCheckpointWrapper(
           this.web3Wrapper,
           this.contractFactory.getERC20DividendCheckpointContract(params.address),
           this.contractFactory,
         );
-      case ModuleName.etherDividendCheckpoint:
+      case ModuleNames.EtherDividendCheckpoint:
         return new EtherDividendCheckpointWrapper(
           this.web3Wrapper,
           this.contractFactory.getEtherDividendCheckpointContract(params.address),

--- a/src/factories/moduleWrapperFactory.ts
+++ b/src/factories/moduleWrapperFactory.ts
@@ -11,51 +11,51 @@ import GeneralTransferManagerWrapper from '../contract_wrappers/modules/transfer
 import GeneralPermissionManagerWrapper from '../contract_wrappers/modules/permission_manager/general_permission_manager_wrapper';
 import ContractFactory from './contractFactory';
 import assert from '../utils/assert';
-import { ModuleNames } from '../types';
+import { ModuleName } from '../types';
 
 interface GetModuleParams {
   address: string;
-  name: ModuleNames;
+  name: ModuleName;
 }
 
 interface GetGeneralPermissionManager extends GetModuleParams {
-  name: ModuleNames.GeneralPermissionManager;
+  name: ModuleName.GeneralPermissionManager;
 }
 
 interface GetCountTransferManager extends GetModuleParams {
-  name: ModuleNames.CountTransferManager;
+  name: ModuleName.CountTransferManager;
 }
 
 interface GetGeneralTransferManager extends GetModuleParams {
-  name: ModuleNames.GeneralTransferManager;
+  name: ModuleName.GeneralTransferManager;
 }
 
 interface GetManualApprovalTransferManager extends GetModuleParams {
-  name: ModuleNames.ManualApprovalTransferManager;
+  name: ModuleName.ManualApprovalTransferManager;
 }
 
 interface GetPercentageTransferManager extends GetModuleParams {
-  name: ModuleNames.PercentageTransferManager;
+  name: ModuleName.PercentageTransferManager;
 }
 
 interface GetVolumeRestrictionTransferManager extends GetModuleParams {
-  name: ModuleNames.VolumeRestrictionTM;
+  name: ModuleName.VolumeRestrictionTM;
 }
 
 interface GetCappedSTO extends GetModuleParams {
-  name: ModuleNames.CappedSTO;
+  name: ModuleName.CappedSTO;
 }
 
 interface GetUSDTieredSTO extends GetModuleParams {
-  name: ModuleNames.UsdTieredSTO;
+  name: ModuleName.UsdTieredSTO;
 }
 
 interface GetERC20DividendCheckpoint extends GetModuleParams {
-  name: ModuleNames.ERC20DividendCheckpoint;
+  name: ModuleName.ERC20DividendCheckpoint;
 }
 
 interface GetEtherDividendCheckpoint extends GetModuleParams {
-  name: ModuleNames.EtherDividendCheckpoint;
+  name: ModuleName.EtherDividendCheckpoint;
 }
 
 interface GetModuleInstance {
@@ -89,64 +89,64 @@ export default class ModuleWrapperFactory {
     assert.isETHAddressHex('address', params.address);
     switch (params.name) {
       // Permission
-      case ModuleNames.GeneralPermissionManager:
+      case ModuleName.GeneralPermissionManager:
         return new GeneralPermissionManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getGeneralPermissionManagerContract(params.address),
           this.contractFactory,
         );
       // TMs
-      case ModuleNames.CountTransferManager:
+      case ModuleName.CountTransferManager:
         return new CountTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getCountTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleNames.GeneralTransferManager:
+      case ModuleName.GeneralTransferManager:
         return new GeneralTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getGeneralTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleNames.ManualApprovalTransferManager:
+      case ModuleName.ManualApprovalTransferManager:
         return new ManualApprovalTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getManualApprovalTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleNames.PercentageTransferManager:
+      case ModuleName.PercentageTransferManager:
         return new PercentageTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getPercentageTransferManagerContract(params.address),
           this.contractFactory,
         );
-      case ModuleNames.VolumeRestrictionTM:
+      case ModuleName.VolumeRestrictionTM:
         return new VolumeRestrictionTransferManagerWrapper(
           this.web3Wrapper,
           this.contractFactory.getVolumeRestrictionTMContract(params.address),
           this.contractFactory,
         );
       // STOs
-      case ModuleNames.CappedSTO:
+      case ModuleName.CappedSTO:
         return new CappedSTOWrapper(
           this.web3Wrapper,
           this.contractFactory.getCappedSTOContract(params.address),
           this.contractFactory,
         );
-      case ModuleNames.UsdTieredSTO:
+      case ModuleName.UsdTieredSTO:
         return new USDTieredSTOWrapper(
           this.web3Wrapper,
           this.contractFactory.getUSDTieredSTOContract(params.address),
           this.contractFactory,
         );
       // Checkpoint
-      case ModuleNames.ERC20DividendCheckpoint:
+      case ModuleName.ERC20DividendCheckpoint:
         return new ERC20DividendCheckpointWrapper(
           this.web3Wrapper,
           this.contractFactory.getERC20DividendCheckpointContract(params.address),
           this.contractFactory,
         );
-      case ModuleNames.EtherDividendCheckpoint:
+      case ModuleName.EtherDividendCheckpoint:
         return new EtherDividendCheckpointWrapper(
           this.web3Wrapper,
           this.contractFactory.getEtherDividendCheckpointContract(params.address),

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,25 +101,25 @@ export enum Features {
 }
 
 export enum PolymathContracts {
-  polyToken = 'PolyToken',
-  moduleRegistry = 'ModuleRegistry',
-  featureRegistry = 'FeatureRegistry',
-  securityTokenRegistry = 'SecurityTokenRegistry',
-  polyUsdOracle = 'PolyUsdOracle',
-  ethUsdOracle = 'EthUsdOracle',
+  PolyToken = 'PolyToken',
+  ModuleRegistry = 'ModuleRegistry',
+  FeatureRegistry = 'FeatureRegistry',
+  SecurityTokenRegistry = 'SecurityTokenRegistry',
+  PolyUsdOracle = 'PolyUsdOracle',
+  EthUsdOracle = 'EthUsdOracle',
 }
 
-export enum ModuleName {
-  generalPermissionManager = 'GeneralPermissionManager',
-  countTransferManager = 'CountTransferManager',
-  generalTransferManager = 'GeneralTransferManager',
-  manualApprovalTransferManager = 'ManualApprovalTransferManager',
-  percentageTransferManager = 'PercentageTransferManager',
-  volumeRestrictionTM = 'VolumeRestrictionTM',
-  cappedSTO = 'CappedSTO',
-  usdTieredSTO = 'USDTieredSTO',
-  erc20DividendCheckpoint = 'ERC20DividendCheckpoint',
-  etherDividendCheckpoint = 'EtherDividendCheckpoint',
+export enum ModuleNames {
+  GeneralPermissionManager = 'GeneralPermissionManager',
+  CountTransferManager = 'CountTransferManager',
+  GeneralTransferManager = 'GeneralTransferManager',
+  ManualApprovalTransferManager = 'ManualApprovalTransferManager',
+  PercentageTransferManager = 'PercentageTransferManager',
+  VolumeRestrictionTM = 'VolumeRestrictionTM',
+  CappedSTO = 'CappedSTO',
+  UsdTieredSTO = 'USDTieredSTO',
+  ERC20DividendCheckpoint = 'ERC20DividendCheckpoint',
+  EtherDividendCheckpoint = 'EtherDividendCheckpoint',
 }
 
 export enum Perms {

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,12 +95,12 @@ export enum FundRaiseType {
   StableCoin = 2,
 }
 
-export enum Features {
+export enum Feature {
   CustomModulesAllowed = 'customModulesAllowed',
   FreezeMintingAllowed = 'freezeMintingAllowed',
 }
 
-export enum PolymathContracts {
+export enum PolymathContract {
   PolyToken = 'PolyToken',
   ModuleRegistry = 'ModuleRegistry',
   FeatureRegistry = 'FeatureRegistry',
@@ -109,7 +109,7 @@ export enum PolymathContracts {
   EthUsdOracle = 'EthUsdOracle',
 }
 
-export enum ModuleNames {
+export enum ModuleName {
   GeneralPermissionManager = 'GeneralPermissionManager',
   CountTransferManager = 'CountTransferManager',
   GeneralTransferManager = 'GeneralTransferManager',
@@ -122,7 +122,7 @@ export enum ModuleNames {
   EtherDividendCheckpoint = 'EtherDividendCheckpoint',
 }
 
-export enum Perms {
+export enum Perm {
   ChangePermission = 'CHANGE_PERMISSION',
   Admin = 'ADMIN',
   Flags = 'FLAGS',
@@ -135,7 +135,7 @@ export enum Perms {
   PreSaleAdmin = 'PRE_SALE_ADMIN',
 }
 
-export enum RestrictionTypes {
+export enum RestrictionType {
   Fixed = 0,
   Percentage = 1,
 }


### PR DESCRIPTION
This PR renames some enums and their properties to be more consistent (following https://basarat.gitbooks.io/typescript/docs/styleguide/styleguide.html#enum):

- Makes all enum names singular (i.e. `PolymathContracts` to `PolymathContract`)
- Makes all enum properties use PascalCase (i.e. `PolymathContract.polyToken` to `PolymathContract.PolyToken`)
- Adapts all internal code using these enums to the aforementioned changes