### PR TITLE
fix: 🐛 return checkpoint times as dates

### DIFF
--- a/src/contract_wrappers/tokens/security_token_wrapper.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper.ts
@@ -67,6 +67,7 @@ import {
   valueToWei,
   valueArrayToWeiArray,
   weiToValue,
+  bigNumberToDate,
 } from '../../utils/convert';
 import functionsUtils from '../../utils/functions_utils';
 
@@ -942,7 +943,9 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
   };
 
   public getCheckpointTimes = async () => {
-    return (await this.contract).getCheckpointTimes.callAsync();
+    const timestamps = await (await this.contract).getCheckpointTimes.callAsync();
+
+    return timestamps.map(bigNumberToDate);
   };
 
   public totalSupplyAt = async (params: CheckpointIdParams) => {


### PR DESCRIPTION
BREAKING CHANGE: change return type of the SecurityToken wrapper's `getCheckpointTimes`
function from `BigNumber[]` to `Date[]`