### PR TITLE
fix: 🐛 disallow SC as a fundraise type for Capped STO

### DIFF
--- a/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
+++ b/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
@@ -27,6 +27,7 @@ import {
   FULL_DECIMALS,
   Partition,
   Perm,
+  CappedSTOFundRaiseType,
 } from '../../../types';
 import SecurityTokenWrapper from '../security_token_wrapper';
 import ContractFactory from '../../../factories/contractFactory';
@@ -4092,7 +4093,7 @@ describe('SecurityTokenWrapper', () => {
         endTime: new Date(2031, 1),
         cap: new BigNumber(1),
         rate: new BigNumber(1),
-        fundRaiseTypes: [FundRaiseType.ETH],
+        fundRaiseType: CappedSTOFundRaiseType.ETH,
         fundsReceiver: '0x2222222222222222222222222222222222222222',
       };
       const mockedCappedParams = {
@@ -4112,7 +4113,7 @@ describe('SecurityTokenWrapper', () => {
         dateToBigNumber(mockedCappedParams.data.endTime).toNumber(),
         valueToWei(mockedCappedParams.data.cap, expectedDecimalsResult).toString(),
         valueToWei(mockedCappedParams.data.rate, FULL_DECIMALS).toString(),
-        mockedCappedParams.data.fundRaiseTypes,
+        [mockedCappedParams.data.fundRaiseType],
         mockedCappedParams.data.fundsReceiver,
       ]);
 
@@ -4139,7 +4140,7 @@ describe('SecurityTokenWrapper', () => {
           endTime: cappedParams.endTime,
           cap: cappedParams.cap,
           rate: cappedParams.rate,
-          fundRaiseTypes: cappedParams.fundRaiseTypes,
+          fundRaiseType: cappedParams.fundRaiseType,
           fundsReceiver: cappedParams.fundsReceiver,
         },
         txData: mockedCappedParams.txData,

--- a/src/contract_wrappers/tokens/security_token_wrapper.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper.ts
@@ -72,6 +72,7 @@ import {
   Subscribe,
   SubscribeAsyncParams,
   TxParams,
+  CappedSTOFundRaiseType,
 } from '../../types';
 import {
   bigNumberToDate,
@@ -791,7 +792,11 @@ interface CappedSTOData {
   endTime: Date;
   cap: BigNumber;
   rate: BigNumber;
-  fundRaiseTypes: FundRaiseType[];
+  /**
+   * In the smart contracts, this parameter is a single-element array.
+   * It has been abstracted and simplified here
+   */
+  fundRaiseType: CappedSTOFundRaiseType;
   fundsReceiver: string;
 }
 
@@ -1818,8 +1823,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
     assert.isNonZeroETHAddressHex('Funds Receiver', data.fundsReceiver);
     assert.isFutureDate(data.startTime, 'Start time date not valid');
     assert.assert(data.endTime > data.startTime, 'End time not valid');
-    assert.isBigNumberGreaterThanZero(data.cap, 'Cap should be greater than 0');
-    assert.assert(data.fundRaiseTypes.length === 1, 'It only selects single fund raise type');
+    assert.isBigNumberGreaterThanZero(data.cap, 'Cap should be greater than 0');    
   };
 
   private usdTieredSTOAssertions = async (data: USDTieredSTOData) => {
@@ -1878,7 +1882,7 @@ export default class SecurityTokenWrapper extends ERC20TokenWrapper {
           dateToBigNumber((params.data as CappedSTOData).endTime).toNumber(),
           valueToWei((params.data as CappedSTOData).cap, decimals).toString(),
           valueToWei((params.data as CappedSTOData).rate, FULL_DECIMALS).toString(),
-          (params.data as CappedSTOData).fundRaiseTypes,
+          [(params.data as CappedSTOData).fundRaiseType], // the module's configure function expects an array
           (params.data as CappedSTOData).fundsReceiver,
         ]);
         break;

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,6 +103,11 @@ export enum FundRaiseType {
   StableCoin = 2,
 }
 
+export enum CappedSTOFundRaiseType {
+  ETH = 0,
+  POLY = 1,
+}
+
 export enum FlagsType {
   IsAccredited,
   CanNotBuyFromSto,


### PR DESCRIPTION
BREAKING CHANGE: `fundRaiseTypes` renamed to `fundRaiseType` and its type changed from
`FundRaiseType[]` to `CappedSTOFundRaiseType` in the `data` parameter of
`addModule` when attaching a Capped STO