### PR TITLE
feat: 🎸 use 3.0 methods to check for ticker availability

### DIFF
--- a/examples/addInvestorToWhitelist.ts
+++ b/examples/addInvestorToWhitelist.ts
@@ -27,7 +27,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
 

--- a/examples/cappedSTO.ts
+++ b/examples/cappedSTO.ts
@@ -28,7 +28,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
   // Get the ticker fee and approve the security token registry to spend

--- a/examples/countTransferManager.ts
+++ b/examples/countTransferManager.ts
@@ -29,7 +29,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
 

--- a/examples/etherDividend.ts
+++ b/examples/etherDividend.ts
@@ -27,7 +27,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
 

--- a/examples/generalPermissionManager.ts
+++ b/examples/generalPermissionManager.ts
@@ -28,7 +28,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
 

--- a/examples/generalTransferManager.ts
+++ b/examples/generalTransferManager.ts
@@ -27,7 +27,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
 

--- a/examples/mintTokenToInvestor.ts
+++ b/examples/mintTokenToInvestor.ts
@@ -27,7 +27,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
   // Get the ticker fee and approve the security token registry to spend

--- a/examples/mintTokenToInvestor.ts
+++ b/examples/mintTokenToInvestor.ts
@@ -59,7 +59,7 @@ window.addEventListener('load', async () => {
 
   console.log('Security Token Generated');
 
-  const tokenAddress = await polymathAPI.securityTokenRegistry.getSecurityTokenAddress(ticker!);
+  const tokenAddress = await polymathAPI.securityTokenRegistry.getSecurityTokenAddress({ ticker: ticker! });
   const tickerSecurityTokenInstance = await polymathAPI.tokenFactory.getSecurityTokenInstanceFromAddress(tokenAddress);
 
   const investorAddress = '0x1111111111111111111111111111111111111111';

--- a/examples/percentageTransferManager.ts
+++ b/examples/percentageTransferManager.ts
@@ -27,7 +27,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
   // Get the ticker fee and approve the security token registry to spend

--- a/examples/registerTicker.ts
+++ b/examples/registerTicker.ts
@@ -56,7 +56,7 @@ window.addEventListener('load', async () => {
     });
   };
 
-  const tickerAvailable = await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  const tickerAvailable = await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
 

--- a/examples/usdTieredSTO.ts
+++ b/examples/usdTieredSTO.ts
@@ -28,7 +28,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
   // Get the ticker fee and approve the security token registry to spend

--- a/examples/volumeRestrictionTransferManager.ts
+++ b/examples/volumeRestrictionTransferManager.ts
@@ -29,7 +29,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
 

--- a/src/contract_wrappers/registries/__tests__/security_token_registry_wrapper.test.ts
+++ b/src/contract_wrappers/registries/__tests__/security_token_registry_wrapper.test.ts
@@ -611,17 +611,11 @@ describe('SecurityTokenRegistryWrapper', () => {
       // Stub the request
       when(mockedOwnerMethod.callAsync()).thenResolve(expectedOwnerResult);
 
-      // Get Ticker Details
-      const expectedTickerDetailsResult = [
-        '0x0123456789012345678901234567890123456789',
-        new BigNumber(1735689600),
-        new BigNumber(1735689605),
-        'ticker',
-        false,
-      ];
-      const mockedGetTickerDetailsMethod = mock(MockedCallMethod);
-      when(mockedContract.getTickerDetails).thenReturn(instance(mockedGetTickerDetailsMethod));
-      when(mockedGetTickerDetailsMethod.callAsync(ticker)).thenResolve(expectedTickerDetailsResult);
+      // Get Ticker Availability
+      const expectedTickerAvailability = true;
+      const mockedTickerAvailableMethod = mock(MockedCallMethod);
+      when(mockedContract.tickerAvailable).thenReturn(instance(mockedTickerAvailableMethod));
+      when(mockedTickerAvailableMethod.callAsync(ticker)).thenResolve(expectedTickerAvailability);
 
       when(mockedWrapper.getAvailableAddressesAsync()).thenResolve([expectedOwnerResult]);
 
@@ -673,9 +667,8 @@ describe('SecurityTokenRegistryWrapper', () => {
           mockedParams.txData,
           mockedParams.safetyFactor,
         ),
-      ).once();
-      verify(mockedContract.getTickerDetails).once();
-      verify(mockedGetTickerDetailsMethod.callAsync(ticker)).once();
+      ).once();      
+      verify(mockedTickerAvailableMethod.callAsync(ticker)).once();
       verify(mockedContract.getTickerRegistrationFee).once();
       verify(mockedTickerRegistrationFeeMethod.callAsync()).once();
       verify(mockedPolyTokenContract.balanceOf).once();
@@ -1187,17 +1180,11 @@ describe('SecurityTokenRegistryWrapper', () => {
       // Stub the request
       when(mockedOwnerMethod.callAsync()).thenResolve(expectedOwnerResult);
 
-      // Get Ticker Details
-      const expectedTickerDetailsResult = [
-        '0x0123456789012345678901234567890123456789',
-        new BigNumber(1735689600),
-        new BigNumber(1735689605),
-        'ticker',
-        false,
-      ];
-      const mockedGetTickerDetailsMethod = mock(MockedCallMethod);
-      when(mockedContract.getTickerDetails).thenReturn(instance(mockedGetTickerDetailsMethod));
-      when(mockedGetTickerDetailsMethod.callAsync(ticker)).thenResolve(expectedTickerDetailsResult);
+      // Get Ticker Availability
+      const expectedTickerAvailability = true;
+      const mockedTickerAvailableMethod = mock(MockedCallMethod);
+      when(mockedContract.tickerAvailable).thenReturn(instance(mockedTickerAvailableMethod));
+      when(mockedTickerAvailableMethod.callAsync(ticker)).thenResolve(expectedTickerAvailability);
 
       when(mockedWrapper.getAvailableAddressesAsync()).thenResolve([expectedOwnerResult]);
 
@@ -1252,9 +1239,8 @@ describe('SecurityTokenRegistryWrapper', () => {
           mockedParams.txData,
           mockedParams.safetyFactor,
         ),
-      ).once();
-      verify(mockedContract.getTickerDetails).once();
-      verify(mockedGetTickerDetailsMethod.callAsync(ticker)).once();
+      ).once();  
+      verify(mockedTickerAvailableMethod.callAsync(ticker)).once();
       verify(mockedContract.getTickerRegistrationFee).once();
       verify(mockedTickerRegistrationFeeMethod.callAsync()).once();
       verify(mockedPolyTokenContract.balanceOf).once();
@@ -1489,7 +1475,7 @@ describe('SecurityTokenRegistryWrapper', () => {
       when(mockedMethod.callAsync(ticker)).thenResolve(expectedResult);
 
       // Real call
-      const result = await target.getSecurityTokenAddress(ticker);
+      const result = await target.getSecurityTokenAddress({ ticker });
       // Result expectation
       expect(result).toBe(expectedResult);
       // Verifications
@@ -1500,39 +1486,33 @@ describe('SecurityTokenRegistryWrapper', () => {
 
   describe('TickerAvailable', () => {
     test('should return false as ticker is registered and deployed', async () => {
-      const expectedResult = [
-        '0x0123456789012345678901234567890123456789',
-        new BigNumber(1),
-        new BigNumber(1),
-        'tokenName',
-        true,
-      ];
+      const expectedResult = false;
       const ticker = 'TICK';
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
-      when(mockedContract.getTickerDetails).thenReturn(instance(mockedMethod));
+      when(mockedContract.tickerAvailable).thenReturn(instance(mockedMethod));
       // Stub the request
       when(mockedMethod.callAsync(ticker)).thenResolve(expectedResult);
 
-      // Real call
-      const result = await target.tickerAvailable({ ticker });
+      // Real call    
+      const result = await target.tickerAvailable({ ticker });      
       // Result expectation
       expect(result).toEqual(false);
       // Verifications
-      verify(mockedContract.getTickerDetails).once();
+      verify(mockedContract.tickerAvailable).once();
       verify(mockedMethod.callAsync(ticker)).once();
     });
 
     test.todo('should return false as ticker is registered and not expired');
 
     test('should return true as ticker is not registered', async () => {
-      const expectedResult = ['', new BigNumber(0), new BigNumber(0), '', false];
+      const expectedResult = true;
       const ticker = 'TICK';
       // Mocked method
       const mockedMethod = mock(MockedCallMethod);
       // Stub the method
-      when(mockedContract.getTickerDetails).thenReturn(instance(mockedMethod));
+      when(mockedContract.tickerAvailable).thenReturn(instance(mockedMethod));
       // Stub the request
       when(mockedMethod.callAsync(ticker)).thenResolve(expectedResult);
 
@@ -1541,7 +1521,7 @@ describe('SecurityTokenRegistryWrapper', () => {
       // Result expectation
       expect(result).toEqual(true);
       // Verifications
-      verify(mockedContract.getTickerDetails).once();
+      verify(mockedContract.tickerAvailable).once();
       verify(mockedMethod.callAsync(ticker)).once();
     });
 
@@ -1558,6 +1538,12 @@ describe('SecurityTokenRegistryWrapper', () => {
       // Stub the method
       const expectedAddrResult = [ownerAddress];
 
+      // Get Ticker Availability
+      const expectedTickerAvailability = false;
+      const mockedTickerAvailableMethod = mock(MockedCallMethod);
+      when(mockedContract.tickerAvailable).thenReturn(instance(mockedTickerAvailableMethod));
+      when(mockedTickerAvailableMethod.callAsync(ticker)).thenResolve(expectedTickerAvailability);
+
       when(mockedWrapper.getAvailableAddressesAsync()).thenResolve(expectedAddrResult);
 
       when(mockedContract.getTickerDetails).thenReturn(instance(mockedMethod));
@@ -1569,7 +1555,9 @@ describe('SecurityTokenRegistryWrapper', () => {
       expect(result).toEqual(true);
       // Verifications
       verify(mockedContract.getTickerDetails).once();
+      verify(mockedContract.tickerAvailable).once();
       verify(mockedMethod.callAsync(ticker)).once();
+      verify(mockedTickerAvailableMethod.callAsync(ticker)).once();
       verify(mockedWrapper.getAvailableAddressesAsync()).once();
     });
 
@@ -1588,6 +1576,12 @@ describe('SecurityTokenRegistryWrapper', () => {
       // Stub the method
       const expectedAddrResult = ['0x1111111111111111111111111111111111111111'];
 
+      // Get Ticker Availability
+      const expectedTickerAvailability = false;
+      const mockedTickerAvailableMethod = mock(MockedCallMethod);
+      when(mockedContract.tickerAvailable).thenReturn(instance(mockedTickerAvailableMethod));
+      when(mockedTickerAvailableMethod.callAsync(ticker)).thenResolve(expectedTickerAvailability);
+
       when(mockedWrapper.getAvailableAddressesAsync()).thenResolve(expectedAddrResult);
 
       when(mockedContract.getTickerDetails).thenReturn(instance(mockedMethod));
@@ -1599,7 +1593,9 @@ describe('SecurityTokenRegistryWrapper', () => {
       expect(result).toEqual(false);
       // Verifications
       verify(mockedContract.getTickerDetails).once();
+      verify(mockedContract.tickerAvailable).once();
       verify(mockedMethod.callAsync(ticker)).once();
+      verify(mockedTickerAvailableMethod.callAsync(ticker)).once();
       verify(mockedWrapper.getAvailableAddressesAsync()).once();
     });
   });

--- a/src/contract_wrappers/registries/__tests__/security_token_registry_wrapper.test.ts
+++ b/src/contract_wrappers/registries/__tests__/security_token_registry_wrapper.test.ts
@@ -1498,7 +1498,7 @@ describe('SecurityTokenRegistryWrapper', () => {
     });
   });
 
-  describe('IsTickerAvailable', () => {
+  describe('TickerAvailable', () => {
     test('should return false as ticker is registered and deployed', async () => {
       const expectedResult = [
         '0x0123456789012345678901234567890123456789',
@@ -1516,7 +1516,7 @@ describe('SecurityTokenRegistryWrapper', () => {
       when(mockedMethod.callAsync(ticker)).thenResolve(expectedResult);
 
       // Real call
-      const result = await target.isTickerAvailable({ ticker });
+      const result = await target.tickerAvailable({ ticker });
       // Result expectation
       expect(result).toEqual(false);
       // Verifications
@@ -1537,7 +1537,7 @@ describe('SecurityTokenRegistryWrapper', () => {
       when(mockedMethod.callAsync(ticker)).thenResolve(expectedResult);
 
       // Real call
-      const result = await target.isTickerAvailable({ ticker });
+      const result = await target.tickerAvailable({ ticker });
       // Result expectation
       expect(result).toEqual(true);
       // Verifications

--- a/src/contract_wrappers/registries/security_token_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/security_token_registry_wrapper.ts
@@ -588,7 +588,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     });
     assert.assert(tickerDetails.status, 'Not deployed');
     const isFrozen = await (await this.securityTokenContract(
-      await this.getSecurityTokenAddress(params.ticker),
+      await this.getSecurityTokenAddress({ ticker: params.ticker }),
     )).transfersFrozen.callAsync();
     assert.assert(isFrozen, 'Transfers not frozen');
     return (await this.contract).refreshSecurityToken.sendTransactionAsync(
@@ -724,7 +724,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     assert.assert(params.registrationDate.getTime() > new Date(0).getTime(), 'Bad registration date');
     assert.isNonZeroETHAddressHex('owner', params.owner);
     if (params.status) {
-      const address = await this.getSecurityTokenAddress(params.ticker);
+      const address = await this.getSecurityTokenAddress({ ticker: params.ticker });
       assert.isNonZeroETHAddressHex('address', address);
     }
     return (await this.contract).modifyExistingTicker.sendTransactionAsync(
@@ -799,7 +799,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     assert.assert(functionsUtils.checksumAddressComparision(address, tickerDetails.owner), 'Not authorised');
     if (tickerDetails.status) {
       const securityTokenOwner = await (await this.securityTokenContract(
-        await this.getSecurityTokenAddress(params.ticker),
+        await this.getSecurityTokenAddress({ ticker: params.ticker }),
       )).owner.callAsync();
       assert.assert(securityTokenOwner === params.newOwner, 'New owner does not match token owner');
     }
@@ -855,22 +855,20 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
   };
 
   /**
-   * Returns the security token address by ticker symbol
-   * @param ticker is the ticker of the security token
+   * Returns the security token address by ticker symbol   
    * @return address string
    */
-  public getSecurityTokenAddress = async (ticker: string) => {
-    return (await this.contract).getSecurityTokenAddress.callAsync(ticker);
-  };
+  public getSecurityTokenAddress = async (params: TickerParams) => {
+    return (await this.contract).getSecurityTokenAddress.callAsync(params.ticker);
+  };  
 
   /**
    * Gets ticker availability
    * @return boolean
    */
-  public isTickerAvailable = async (params: TickerParams) => {
-    const result = await this.getTickerDetailsInternal(params.ticker);
-    return this.isTickerAvailableInternal(result.registrationDate, result.expiryDate, result.status);
-  };
+  public tickerAvailable = async (params: TickerParams) => {
+    return (await this.contract).tickerAvailable.callAsync(params.ticker);
+  }
 
   /**
    * Knows if the ticker was registered by the user
@@ -878,7 +876,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
    */
   public isTickerRegisteredByCurrentIssuer = async (params: TickerParams) => {
     const result = await this.getTickerDetailsInternal(params.ticker);
-    if (this.isTickerAvailableInternal(result.registrationDate, result.expiryDate, result.status)) {
+    if (await this.tickerAvailable({ ticker: params.ticker  })) {
       return false;
     }
     return result.owner === (await this.getDefaultFromAddress());
@@ -906,7 +904,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     );
     assert.isETHAddressHex('owner', params.owner);
     if (params.status) {
-      const address = await this.getSecurityTokenAddress(params.ticker);
+      const address = await this.getSecurityTokenAddress({ ticker: params.ticker });
       assert.isNonZeroETHAddressHex('address', address);
     }
     return (await this.contract).modifyTicker.sendTransactionAsync(
@@ -1220,16 +1218,6 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     return logs;
   };
 
-  private isTickerAvailableInternal = (registrationDate: Date, expiryDate: Date, isDeployed: boolean) => {
-    if (registrationDate.getTime() === new Date(0).getTime()) {
-      return true;
-    }
-    if (!isDeployed && expiryDate.getTime() > Date.now()) {
-      return true;
-    }
-    return false;
-  };
-
   private getTickerDetailsInternal = async (ticker: string) => {
     const result = await (await this.contract).getTickerDetails.callAsync(ticker);
     const typedResult: TickerDetails = {
@@ -1267,7 +1255,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     assert.isETHAddressHex('owner', owner);
     assert.assert(ticker.length > 0 && ticker.length <= 10, 'Bad ticker, must be 1 to 10 characters');
     assert.assert(
-      await this.isTickerAvailable({
+      await this.tickerAvailable({
         ticker,
       }),
       'Ticker is not available',
@@ -1289,7 +1277,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     assert.isNonZeroETHAddressHex('securityToken', securityToken);
     assert.isNonZeroETHAddressHex(
       'Security token not registered for ticker',
-      await this.getSecurityTokenAddress(ticker),
+      await this.getSecurityTokenAddress({ ticker }),
     );
   };
 }

--- a/src/factories/tokenWrapperFactory.ts
+++ b/src/factories/tokenWrapperFactory.ts
@@ -77,7 +77,7 @@ export default class TokenWrapperFactory {
    * @memberof SecurityTokenWrapperFactory
    */
   public getSecurityTokenInstanceFromTicker = async (ticker: string): Promise<SecurityTokenWrapper> => {
-    const address = await this.securityTokenRegistry.getSecurityTokenAddress(ticker);
+    const address = await this.securityTokenRegistry.getSecurityTokenAddress({ ticker });
     assert.isNonZeroETHAddressHex('address', address);
     return new SecurityTokenWrapper(
       this.web3Wrapper,


### PR DESCRIPTION
removed obsolete STR internal methods (that weren't working properly)
and fixed the signature of `getSecurityTokenAddress`

BREAKING CHANGE: rename Security Token Registry wrapper's `isTickerAvailable` to
`tickerAvailable`, `getSecurityTokenAddress` now receives `{ ticker:
string }` instead of just `string`