### PR TITLE
fix: 🐛 Solved warnings on console

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@0x/subproviders": "^4.1.1",
     "@0x/types": "^2.4.0",
     "@0x/typescript-typings": "^4.2.3",
-    "@polymathnetwork/abi-wrappers": "3.0.0-beta.6",
+    "@polymathnetwork/abi-wrappers": "3.0.0-beta.7",
     "@types/semver": "^6.0.1",
     "ethereumjs-blockstream": "6.0.0",
     "ethereumjs-util": "^6.1.0",

--- a/src/PolymathAPI.ts
+++ b/src/PolymathAPI.ts
@@ -25,6 +25,7 @@ import {
   Module,
   ERC20Detailed,
 } from '@polymathnetwork/abi-wrappers';
+import _ from 'lodash';
 import PolymathRegistryWrapper from './contract_wrappers/registries/polymath_registry_wrapper';
 import SecurityTokenRegistryWrapper from './contract_wrappers/registries/security_token_registry_wrapper';
 import PolyTokenWrapper from './contract_wrappers/tokens/poly_token_wrapper';
@@ -136,14 +137,26 @@ export class PolymathAPI {
     const abiArray = [
       // Registries
       FeatureRegistry.abi,
-      ModuleRegistry.abi,
+      ModuleRegistry.abi.filter(
+        a =>
+          !(
+            a.type === 'function' &&
+            a.name === 'useModule' &&
+            _.isEqual(a.inputs, [
+              {
+                name: '_moduleFactory',
+                type: 'address',
+              },
+            ])
+          ),
+      ),
       PolymathRegistry.abi,
       ISecurityTokenRegistry.abi.filter(
         a =>
-          a.type !== 'event' &&
-          a.name !== 'RegisterTicker' &&
-          a.inputs ===
-            [
+          !(
+            a.type === 'event' &&
+            a.name === 'RegisterTicker' &&
+            _.isEqual(a.inputs, [
               { indexed: true, name: '_owner', type: 'address' },
               { indexed: false, name: '_ticker', type: 'string' },
               { indexed: false, name: '_name', type: 'string' },
@@ -151,7 +164,8 @@ export class PolymathAPI {
               { indexed: true, name: '_expiryDate', type: 'uint256' },
               { indexed: false, name: '_fromAdmin', type: 'bool' },
               { indexed: false, name: '_registrationFee', type: 'uint256' },
-            ],
+            ])
+          ),
       ),
       // Modules
       ModuleFactory.abi,

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,10 +695,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@polymathnetwork/abi-wrappers@3.0.0-beta.6":
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@polymathnetwork/abi-wrappers/-/abi-wrappers-3.0.0-beta.6.tgz#65188f96ec752421ece4337d3ed00721c46b8313"
-  integrity sha512-Db3D0rDNuxWiN+xyJ6J8H7FZ+ypZJ27gMoBUUH6lMf5p7NPDfRnegUtlkuq/QYG8H6b/yCHocaiVJrO9C1HfOA==
+"@polymathnetwork/abi-wrappers@3.0.0-beta.7":
+  version "3.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@polymathnetwork/abi-wrappers/-/abi-wrappers-3.0.0-beta.7.tgz#83b556dfedebc6a03e99144fc1e5b6ff89463c80"
+  integrity sha512-ZRGPI+ZaakRwTrnFuEy20LpPs1ZGpk6jhKK2lFkJ8DXs817ZIslltuWmUq6CnI6jc8o1Y6vpOc5Sxz+0pW0U+A==
   dependencies:
     "@0x/base-contract" "^5.1.1"
     "@0x/utils" "^4.4.0"


### PR DESCRIPTION
Warnings for multiple uses of useModule doesn't appear any more. The
backwards compatibility method was removed from ABI.