### PR TITLE
Fix getLogsAsync

### DIFF
--- a/examples/lockUpTransferManager.ts
+++ b/examples/lockUpTransferManager.ts
@@ -1,8 +1,8 @@
 import { RedundantSubprovider, RPCSubprovider, Web3ProviderEngine } from '@0x/subproviders';
+import { BigNumber, LockUpTransferManagerEvents } from '@polymathnetwork/abi-wrappers';
 import ModuleFactoryWrapper from '../src/contract_wrappers/modules/module_factory_wrapper';
 import { ApiConstructorParams, PolymathAPI } from '../src/PolymathAPI';
 import { ModuleName, ModuleType } from '../src';
-import { BigNumber, ModuleRegistryEvents, LockUpTransferManagerEvents } from '@polymathnetwork/abi-wrappers';
 
 // This file acts as a valid sandbox for using a lockup restriction transfer manager module on an unlocked node (like ganache)
 window.addEventListener('load', async () => {
@@ -27,7 +27,7 @@ window.addEventListener('load', async () => {
   const tokenName = prompt('Token Name', '');
 
   // Double check available
-  await polymathAPI.securityTokenRegistry.isTickerAvailable({
+  await polymathAPI.securityTokenRegistry.tickerAvailable({
     ticker: ticker!,
   });
   // Get the ticker fee and approve the security token registry to spend
@@ -191,7 +191,7 @@ window.addEventListener('load', async () => {
   });
   // Example removing lockup from beneficiary 2 and removing lockup type
   await lockUpTM.removeLockUpFromUser({ userAddress: randomBeneficiary2, lockupName: thirdLockUpName });
-  await lockUpTM.removeLockupType({lockupName: thirdLockUpName});
+  await lockUpTM.removeLockupType({ lockupName: thirdLockUpName });
 
   // Try to transfer 50, it is below lockup and will pass
   await tickerSecurityTokenInstance.transfer({ to: randomBeneficiary2, value: new BigNumber(50) });

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@0x/subproviders": "^4.1.1",
     "@0x/types": "^2.4.0",
     "@0x/typescript-typings": "^4.2.3",
-    "@polymathnetwork/abi-wrappers": "3.0.0-beta.7",
+    "@polymathnetwork/abi-wrappers": "3.0.0-beta.8",
     "@types/semver": "^6.0.1",
     "ethereumjs-blockstream": "6.0.0",
     "ethereumjs-util": "^6.1.0",

--- a/src/PolymathAPI.ts
+++ b/src/PolymathAPI.ts
@@ -4,29 +4,28 @@ import {
   BigNumber,
   providerUtils,
   Provider,
-  PolymathRegistry,
-  ISecurityTokenRegistry,
-  ISecurityToken,
-  PolyToken,
-  ModuleRegistry,
-  CappedSTO,
-  ModuleFactory,
-  USDTieredSTO,
-  FeatureRegistry,
-  GeneralTransferManager,
-  GeneralPermissionManager,
-  ERC20DividendCheckpoint,
-  ManualApprovalTransferManager,
-  CountTransferManager,
-  PercentageTransferManager,
-  LockUpTransferManager,
-  EtherDividendCheckpoint,
-  VolumeRestrictionTransferManager,
-  PolyTokenFaucet,
-  Module,
-  ERC20Detailed,
+  FeatureRegistryContract,
+  ModuleRegistryContract,
+  PolymathRegistryContract,
+  ISecurityTokenRegistryContract,
+  ModuleFactoryContract,
+  ModuleContract,
+  ERC20DividendCheckpointContract,
+  EtherDividendCheckpointContract,
+  GeneralPermissionManagerContract,
+  CappedSTOContract,
+  USDTieredSTOContract,
+  CountTransferManagerContract,
+  GeneralTransferManagerContract,
+  ManualApprovalTransferManagerContract,
+  PercentageTransferManagerContract,
+  LockUpTransferManagerContract,
+  ERC20DetailedContract,
+  PolyTokenContract,
+  PolyTokenFaucetContract,
+  ISecurityTokenContract,
+  VolumeRestrictionTMContract,
 } from '@polymathnetwork/abi-wrappers';
-import _ from 'lodash';
 import PolymathRegistryWrapper from './contract_wrappers/registries/polymath_registry_wrapper';
 import SecurityTokenRegistryWrapper from './contract_wrappers/registries/security_token_registry_wrapper';
 import PolyTokenWrapper from './contract_wrappers/tokens/poly_token_wrapper';
@@ -137,60 +136,33 @@ export class PolymathAPI {
 
     const abiArray = [
       // Registries
-      FeatureRegistry.abi,
-      ModuleRegistry.abi.filter(
-        a =>
-          !(
-            a.type === 'function' &&
-            a.name === 'useModule' &&
-            _.isEqual(a.inputs, [
-              {
-                name: '_moduleFactory',
-                type: 'address',
-              },
-            ])
-          ),
-      ),
-      PolymathRegistry.abi,
-      ISecurityTokenRegistry.abi.filter(
-        a =>
-          !(
-            a.type === 'event' &&
-            a.name === 'RegisterTicker' &&
-            _.isEqual(a.inputs, [
-              { indexed: true, name: '_owner', type: 'address' },
-              { indexed: false, name: '_ticker', type: 'string' },
-              { indexed: false, name: '_name', type: 'string' },
-              { indexed: true, name: '_registrationDate', type: 'uint256' },
-              { indexed: true, name: '_expiryDate', type: 'uint256' },
-              { indexed: false, name: '_fromAdmin', type: 'bool' },
-              { indexed: false, name: '_registrationFee', type: 'uint256' },
-            ])
-          ),
-      ),
+      FeatureRegistryContract.ABI(),
+      ModuleRegistryContract.ABI(),
+      PolymathRegistryContract.ABI(),
+      ISecurityTokenRegistryContract.ABI(),
       // Modules
-      ModuleFactory.abi,
-      Module.abi,
+      ModuleFactoryContract.ABI(),
+      ModuleContract.ABI(),
       // Checkpoint
-      ERC20DividendCheckpoint.abi,
-      EtherDividendCheckpoint.abi,
+      ERC20DividendCheckpointContract.ABI(),
+      EtherDividendCheckpointContract.ABI(),
       // Permission
-      GeneralPermissionManager.abi,
+      GeneralPermissionManagerContract.ABI(),
       // STO
-      CappedSTO.abi,
-      USDTieredSTO.abi,
+      CappedSTOContract.ABI(),
+      USDTieredSTOContract.ABI(),
       // Transfer
-      CountTransferManager.abi,
-      GeneralTransferManager.abi,
-      ManualApprovalTransferManager.abi,
-      PercentageTransferManager.abi,
-      LockUpTransferManager.abi,
-      VolumeRestrictionTransferManager.abi,
+      CountTransferManagerContract.ABI(),
+      GeneralTransferManagerContract.ABI(),
+      ManualApprovalTransferManagerContract.ABI(),
+      PercentageTransferManagerContract.ABI(),
+      LockUpTransferManagerContract.ABI(),
+      VolumeRestrictionTMContract.ABI(),
       // Tokens
-      ERC20Detailed.abi,
-      PolyToken.abi,
-      PolyTokenFaucet.abi,
-      ISecurityToken.abi,
+      ERC20DetailedContract.ABI(),
+      PolyTokenContract.ABI(),
+      PolyTokenFaucetContract.ABI(),
+      ISecurityTokenContract.ABI(),
     ];
 
     abiArray.forEach((abi): void => {

--- a/src/contract_wrappers/modules/checkpoint/erc20_dividend_checkpoint_wrapper.ts
+++ b/src/contract_wrappers/modules/checkpoint/erc20_dividend_checkpoint_wrapper.ts
@@ -11,11 +11,8 @@ import {
   ERC20DividendCheckpointSetWithholdingFixedEventArgs,
   ERC20DetailedContract,
   BigNumber,
-  ContractAbi,
   LogWithDecodedArgs,
-  TxData,
   Web3Wrapper,
-  ERC20DividendCheckpoint,
 } from '@polymathnetwork/abi-wrappers';
 import { schemas } from '@0x/json-schemas';
 import assert from '../../../utils/assert';
@@ -31,8 +28,6 @@ import {
   Perm,
 } from '../../../types';
 import { numberToBigNumber, dateToBigNumber, stringToBytes32, valueToWei } from '../../../utils/convert';
-
-const EXCLUDED_ADDRESS_LIMIT = 150;
 
 interface ERC20DividendDepositedSubscribeAsyncParams extends SubscribeAsyncParams {
   eventName: ERC20DividendCheckpointEvents.ERC20DividendDeposited;
@@ -160,8 +155,6 @@ interface CreateDividendWithCheckpointAndExclusionsParams extends CreateDividend
  * This class includes the functionality related to interacting with the ERC20DividendCheckpoint contract.
  */
 export default class ERC20DividendCheckpointWrapper extends DividendCheckpointWrapper {
-  public abi: ContractAbi = ERC20DividendCheckpoint.abi;
-
   protected contract: Promise<ERC20DividendCheckpointContract>;
 
   protected erc20DetailedContract = async (address: string): Promise<ERC20DetailedContract> => {
@@ -307,11 +300,10 @@ export default class ERC20DividendCheckpointWrapper extends DividendCheckpointWr
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      ERC20DividendCheckpoint.abi,
       params.callback,
       params.isVerbose,
     );
@@ -336,7 +328,6 @@ export default class ERC20DividendCheckpointWrapper extends DividendCheckpointWr
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      ERC20DividendCheckpoint.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/checkpoint/ether_dividend_checkpoint_wrapper.ts
+++ b/src/contract_wrappers/modules/checkpoint/ether_dividend_checkpoint_wrapper.ts
@@ -14,9 +14,7 @@ import {
   EtherDividendCheckpointUpdateDividendDatesEventArgs,
   EtherDividendCheckpointPauseEventArgs,
   EtherDividendCheckpointUnpauseEventArgs,
-  EtherDividendCheckpoint,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -34,8 +32,6 @@ import {
   Perm,
 } from '../../../types';
 import { numberToBigNumber, dateToBigNumber, stringToBytes32, valueToWei } from '../../../utils/convert';
-
-const EXCLUDED_ADDRESS_LIMIT = 150;
 
 interface EtherDividendDepositedSubscribeAsyncParams extends SubscribeAsyncParams {
   eventName: EtherDividendCheckpointEvents.EtherDividendDeposited;
@@ -229,8 +225,6 @@ interface CreateDividendWithCheckpointAndExclusionsParams extends TxParams {
  * This class includes the functionality related to interacting with the EtherDividendCheckpoint contract.
  */
 export default class EtherDividendCheckpointWrapper extends DividendCheckpointWrapper {
-  public abi: ContractAbi = EtherDividendCheckpoint.abi;
-
   protected contract: Promise<EtherDividendCheckpointContract>;
 
   protected getDecimals = async (): Promise<BigNumber> => {
@@ -367,11 +361,10 @@ export default class EtherDividendCheckpointWrapper extends DividendCheckpointWr
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      EtherDividendCheckpoint.abi,
       params.callback,
       params.isVerbose,
     );
@@ -396,7 +389,6 @@ export default class EtherDividendCheckpointWrapper extends DividendCheckpointWr
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      EtherDividendCheckpoint.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/module_factory_wrapper.ts
+++ b/src/contract_wrappers/modules/module_factory_wrapper.ts
@@ -1,8 +1,6 @@
 import {
   BigNumber,
-  ContractAbi,
   LogWithDecodedArgs,
-  ModuleFactory,
   ModuleFactoryChangeSTVersionBoundEventArgs,
   ModuleFactoryContract,
   ModuleFactoryEventArgs,
@@ -112,8 +110,6 @@ interface ChangeSTVersionBoundsParams extends TxParams {
  * This class includes the functionality related to interacting with the ModuleFactory contract.
  */
 export default class ModuleFactoryWrapper extends ContractWrapper {
-  public abi: ContractAbi = ModuleFactory.abi;
-
   protected contract: Promise<ModuleFactoryContract>;
 
   /**
@@ -334,11 +330,10 @@ export default class ModuleFactoryWrapper extends ContractWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      ModuleFactory.abi,
       params.callback,
       params.isVerbose,
     );
@@ -361,7 +356,6 @@ export default class ModuleFactoryWrapper extends ContractWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      ModuleFactory.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/module_wrapper.ts
+++ b/src/contract_wrappers/modules/module_wrapper.ts
@@ -3,9 +3,7 @@ import {
   ModuleFactoryContract,
   PolyTokenContract,
   ERC20DetailedContract,
-  Module,
   Web3Wrapper,
-  ContractAbi,
   TxData,
 } from '@polymathnetwork/abi-wrappers';
 import ContractWrapper from '../contract_wrapper';
@@ -23,8 +21,6 @@ interface ReclaimERC20Params extends TxParams {
  * This class includes the functionality related to interacting with the General Permission Manager contract.
  */
 export default class ModuleWrapper extends ContractWrapper {
-  public abi: ContractAbi = Module.abi;
-
   protected contract: Promise<GenericModuleContract>;
 
   protected contractFactory: ContractFactory;

--- a/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper.ts
@@ -4,9 +4,7 @@ import {
   GeneralPermissionManagerEvents,
   GeneralPermissionManagerChangePermissionEventArgs,
   GeneralPermissionManagerAddDelegateEventArgs,
-  GeneralPermissionManager,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
 } from '@polymathnetwork/abi-wrappers';
 import _ from 'lodash';
@@ -120,8 +118,6 @@ interface PermissionsPerModule {
  * This class includes the functionality related to interacting with the General Permission Manager contract.
  */
 export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
-  public abi: ContractAbi = GeneralPermissionManager.abi;
-
   protected contract: Promise<GeneralPermissionManagerContract>;
 
   /**
@@ -237,16 +233,13 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
       return value[0];
     }); // [module1: [[module1, perm1], [module1, perm2]], ...]
     const typedResult: PermissionsPerModule[] = [];
-    _.forEach(
-      groupedResult,
-      (value, key): void => {
-        const permissionsPerModule: PermissionsPerModule = {
-          module: key,
-          permissions: value.map(pair => parsePermBytes32Value(pair[1] as string)),
-        };
-        typedResult.push(permissionsPerModule);
-      },
-    );
+    _.forEach(groupedResult, (value, key): void => {
+      const permissionsPerModule: PermissionsPerModule = {
+        module: key,
+        permissions: value.map(pair => parsePermBytes32Value(pair[1] as string)),
+      };
+      typedResult.push(permissionsPerModule);
+    });
     return typedResult;
   };
 
@@ -267,11 +260,10 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      GeneralPermissionManager.abi,
       params.callback,
       params.isVerbose,
     );
@@ -296,7 +288,6 @@ export default class GeneralPermissionManagerWrapper extends ModuleWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      GeneralPermissionManager.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/sto/capped_sto_wrapper.ts
+++ b/src/contract_wrappers/modules/sto/capped_sto_wrapper.ts
@@ -7,9 +7,7 @@ import {
   CappedSTOSetFundRaiseTypesEventArgs,
   CappedSTOPauseEventArgs,
   CappedSTOUnpauseEventArgs,
-  CappedSTO,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -135,8 +133,6 @@ interface CappedSTODetails {
  * This class includes the functionality related to interacting with the CappedSTO contract.
  */
 export default class CappedSTOWrapper extends STOWrapper {
-  public abi: ContractAbi = CappedSTO.abi;
-
   protected contract: Promise<CappedSTOContract>;
 
   /**
@@ -281,11 +277,10 @@ export default class CappedSTOWrapper extends STOWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      CappedSTO.abi,
       params.callback,
       params.isVerbose,
     );
@@ -308,7 +303,6 @@ export default class CappedSTOWrapper extends STOWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      CappedSTO.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper.ts
@@ -16,10 +16,8 @@ import {
   USDTieredSTOSetTreasuryWalletEventArgs,
   USDTieredSTOTokenPurchaseEventArgs,
   USDTieredSTOUnpauseEventArgs,
-  USDTieredSTO,
   Web3Wrapper,
   BigNumber,
-  ContractAbi,
   LogWithDecodedArgs,
 } from '@polymathnetwork/abi-wrappers';
 import { schemas } from '@0x/json-schemas';
@@ -394,8 +392,6 @@ interface MintedByTier {
  * This class includes the functionality related to interacting with the USDTieredSTO contract.
  */
 export default class USDTieredSTOWrapper extends STOWrapper {
-  public abi: ContractAbi = USDTieredSTO.abi;
-
   protected contract: Promise<USDTieredSTOContract>;
 
   protected generalTransferManagerContract = async (address: string): Promise<GeneralTransferManagerContract> => {
@@ -924,11 +920,10 @@ export default class USDTieredSTOWrapper extends STOWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      USDTieredSTO.abi,
       params.callback,
       params.isVerbose,
     );
@@ -951,7 +946,6 @@ export default class USDTieredSTOWrapper extends STOWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      USDTieredSTO.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/transfer_manager/count_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/count_transfer_manager_wrapper.ts
@@ -5,9 +5,7 @@ import {
   CountTransferManagerModifyHolderCountEventArgs,
   CountTransferManagerPauseEventArgs,
   CountTransferManagerUnpauseEventArgs,
-  CountTransferManager,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -82,8 +80,6 @@ interface ChangeHolderCountParams extends TxParams {
  * This class includes the functionality related to interacting with the Count Transfer Manager contract.
  */
 export default class CountTransferManagerWrapper extends ModuleWrapper {
-  public abi: ContractAbi = CountTransferManager.abi;
-
   protected contract: Promise<CountTransferManagerContract>;
 
   /**
@@ -160,11 +156,10 @@ export default class CountTransferManagerWrapper extends ModuleWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      CountTransferManager.abi,
       params.callback,
       params.isVerbose,
     );
@@ -187,7 +182,6 @@ export default class CountTransferManagerWrapper extends ModuleWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      CountTransferManager.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/transfer_manager/general_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/general_transfer_manager_wrapper.ts
@@ -9,9 +9,7 @@ import {
   GeneralTransferManagerChangeDefaultsEventArgs,
   GeneralTransferManagerPauseEventArgs,
   GeneralTransferManagerUnpauseEventArgs,
-  GeneralTransferManager,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -324,8 +322,6 @@ interface KYCDataWithInvestor extends KYCData {
  * This class includes the functionality related to interacting with the General Transfer Manager contract.
  */
 export default class GeneralTransferManagerWrapper extends ModuleWrapper {
-  public abi: ContractAbi = GeneralTransferManager.abi;
-
   protected contract: Promise<GeneralTransferManagerContract>;
 
   /**
@@ -763,11 +759,10 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      GeneralTransferManager.abi,
       params.callback,
       params.isVerbose,
     );
@@ -792,7 +787,6 @@ export default class GeneralTransferManagerWrapper extends ModuleWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      GeneralTransferManager.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/transfer_manager/lock_up_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/lock_up_transfer_manager_wrapper.ts
@@ -1,7 +1,5 @@
 import {
   BigNumber,
-  ContractAbi,
-  LockUpTransferManager,
   LockUpTransferManagerAddLockUpToUserEventArgs,
   LockUpTransferManagerAddNewLockUpTypeEventArgs,
   LockUpTransferManagerContract,
@@ -246,8 +244,6 @@ interface VerifyTransfer {
  * This class includes the functionality related to interacting with the LockUp Transfer Manager contract.
  */
 export default class LockUpTransferManagerWrapper extends ModuleWrapper {
-  public abi: ContractAbi = LockUpTransferManager.abi;
-
   protected contract: Promise<LockUpTransferManagerContract>;
 
   /**
@@ -715,11 +711,10 @@ export default class LockUpTransferManagerWrapper extends ModuleWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      LockUpTransferManager.abi,
       params.callback,
       params.isVerbose,
     );
@@ -744,7 +739,6 @@ export default class LockUpTransferManagerWrapper extends ModuleWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      LockUpTransferManager.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/transfer_manager/manual_approval_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/manual_approval_transfer_manager_wrapper.ts
@@ -7,9 +7,7 @@ import {
   ManualApprovalTransferManagerRevokeManualApprovalEventArgs,
   ManualApprovalTransferManagerPauseEventArgs,
   ManualApprovalTransferManagerUnpauseEventArgs,
-  ManualApprovalTransferManager,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -190,8 +188,6 @@ interface Approval {
  * This class includes the functionality related to interacting with the ManualApproval Transfer Manager contract.
  */
 export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper {
-  public abi: ContractAbi = ManualApprovalTransferManager.abi;
-
   protected contract: Promise<ManualApprovalTransferManagerContract>;
 
   /**
@@ -456,11 +452,10 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      ManualApprovalTransferManager.abi,
       params.callback,
       params.isVerbose,
     );
@@ -485,7 +480,6 @@ export default class ManualApprovalTransferManagerWrapper extends ModuleWrapper 
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      ManualApprovalTransferManager.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/transfer_manager/percentage_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/percentage_transfer_manager_wrapper.ts
@@ -7,9 +7,7 @@ import {
   PercentageTransferManagerSetAllowPrimaryIssuanceEventArgs,
   PercentageTransferManagerPauseEventArgs,
   PercentageTransferManagerUnpauseEventArgs,
-  PercentageTransferManager,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -27,7 +25,7 @@ import {
   Perm,
   PERCENTAGE_DECIMALS,
 } from '../../../types';
-import {parseTransferResult, valueToWei, weiToValue} from '../../../utils/convert';
+import { parseTransferResult, valueToWei, weiToValue } from '../../../utils/convert';
 
 interface ModifyHolderPercentageSubscribeAsyncParams extends SubscribeAsyncParams {
   eventName: PercentageTransferManagerEvents.ModifyHolderPercentage;
@@ -129,8 +127,6 @@ interface SetAllowPrimaryIssuanceParams extends TxParams {
  * This class includes the functionality related to interacting with the Percentage Transfer Manager contract.
  */
 export default class PercentageTransferManagerWrapper extends ModuleWrapper {
-  public abi: ContractAbi = PercentageTransferManager.abi;
-
   protected contract: Promise<PercentageTransferManagerContract>;
 
   /**
@@ -256,11 +252,10 @@ export default class PercentageTransferManagerWrapper extends ModuleWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      PercentageTransferManager.abi,
       params.callback,
       params.isVerbose,
     );
@@ -285,7 +280,6 @@ export default class PercentageTransferManagerWrapper extends ModuleWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      PercentageTransferManager.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/modules/transfer_manager/volume_restriction_transfer_manager_wrapper.ts
+++ b/src/contract_wrappers/modules/transfer_manager/volume_restriction_transfer_manager_wrapper.ts
@@ -17,9 +17,7 @@ import {
   VolumeRestrictionTMDefaultDailyRestrictionRemovedEventArgs,
   VolumeRestrictionTMPauseEventArgs,
   VolumeRestrictionTMUnpauseEventArgs,
-  VolumeRestrictionTransferManager,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -339,8 +337,6 @@ interface IndividualRestriction {
  * This class includes the functionality related to interacting with the Volume Restriction Transfer Manager contract.
  */
 export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapper {
-  public abi: ContractAbi = VolumeRestrictionTransferManager.abi;
-
   protected contract: Promise<VolumeRestrictionTMContract>;
 
   /**
@@ -925,11 +921,10 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      VolumeRestrictionTransferManager.abi,
       params.callback,
       params.isVerbose,
     );
@@ -954,7 +949,6 @@ export default class VolumeRestrictionTransferManagerWrapper extends ModuleWrapp
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      VolumeRestrictionTransferManager.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/registries/feature_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/feature_registry_wrapper.ts
@@ -4,9 +4,7 @@ import {
   FeatureRegistryEvents,
   FeatureRegistryChangeFeatureStatusEventArgs,
   FeatureRegistryOwnershipTransferredEventArgs,
-  FeatureRegistry,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
 } from '@polymathnetwork/abi-wrappers';
 import { schemas } from '@0x/json-schemas';
@@ -75,8 +73,6 @@ interface SetFeatureStatusParams extends TxParams {
  * This class includes the functionality related to interacting with the FeatureRegistry contract.
  */
 export default class FeatureRegistryWrapper extends ContractWrapper {
-  public abi: ContractAbi = FeatureRegistry.abi;
-
   protected contract: Promise<FeatureRegistryContract>;
 
   /**
@@ -146,11 +142,10 @@ export default class FeatureRegistryWrapper extends ContractWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      FeatureRegistry.abi,
       params.callback,
       params.isVerbose,
     );
@@ -173,7 +168,6 @@ export default class FeatureRegistryWrapper extends ContractWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      FeatureRegistry.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/registries/polymath_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/polymath_registry_wrapper.ts
@@ -4,9 +4,7 @@ import {
   PolymathRegistryEvents,
   PolymathRegistryChangeAddressEventArgs,
   PolymathRegistryOwnershipTransferredEventArgs,
-  PolymathRegistry,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
 } from '@polymathnetwork/abi-wrappers';
 import { schemas } from '@0x/json-schemas';
@@ -73,8 +71,6 @@ interface ChangeAddressParams extends TxParams {
  * This class includes the functionality related to interacting with the PolymathRegistry contract.
  */
 export default class PolymathRegistryWrapper extends ContractWrapper {
-  public abi: ContractAbi = PolymathRegistry.abi;
-
   protected contract: Promise<PolymathRegistryContract>;
 
   /**
@@ -175,11 +171,10 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      PolymathRegistry.abi,
       params.callback,
       params.isVerbose,
     );
@@ -202,7 +197,6 @@ export default class PolymathRegistryWrapper extends ContractWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      PolymathRegistry.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/registries/security_token_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/security_token_registry_wrapper.ts
@@ -19,9 +19,7 @@ import {
   ISecurityTokenRegistryProtocolFactoryRemovedEventArgs,
   ISecurityTokenContract,
   PolyTokenContract,
-  ISecurityTokenRegistry,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
@@ -494,8 +492,6 @@ interface TickerDetails {
  * This class includes the functionality related to interacting with the ISecurityTokenRegistry contract.
  */
 export default class SecurityTokenRegistryWrapper extends ContractWrapper {
-  public abi: ContractAbi = ISecurityTokenRegistry.abi;
-
   protected contract: Promise<ISecurityTokenRegistryContract>;
 
   protected contractFactory: ContractFactory;
@@ -855,12 +851,12 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
   };
 
   /**
-   * Returns the security token address by ticker symbol   
+   * Returns the security token address by ticker symbol
    * @return address string
    */
   public getSecurityTokenAddress = async (params: TickerParams) => {
     return (await this.contract).getSecurityTokenAddress.callAsync(params.ticker);
-  };  
+  };
 
   /**
    * Gets ticker availability
@@ -868,7 +864,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
    */
   public tickerAvailable = async (params: TickerParams) => {
     return (await this.contract).tickerAvailable.callAsync(params.ticker.toUpperCase());
-  }
+  };
 
   /**
    * Knows if the ticker was registered by the user
@@ -876,7 +872,7 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
    */
   public isTickerRegisteredByCurrentIssuer = async (params: TickerParams) => {
     const result = await this.getTickerDetailsInternal(params.ticker);
-    if (await this.tickerAvailable({ ticker: params.ticker  })) {
+    if (await this.tickerAvailable({ ticker: params.ticker })) {
       return false;
     }
     return result.owner === (await this.getDefaultFromAddress());
@@ -1184,11 +1180,10 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      ISecurityTokenRegistry.abi,
       params.callback,
       params.isVerbose,
     );
@@ -1213,7 +1208,6 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      ISecurityTokenRegistry.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
+++ b/src/contract_wrappers/tokens/__tests__/security_token_wrapper.test.ts
@@ -10,12 +10,12 @@ import {
   ethers,
   BigNumber,
   Web3Wrapper,
-  CountTransferManager,
-  ERC20DividendCheckpoint,
-  CappedSTO,
-  USDTieredSTO,
-  PercentageTransferManager,
-  EtherDividendCheckpoint,
+  CountTransferManagerContract,
+  ERC20DividendCheckpointContract,
+  CappedSTOContract,
+  USDTieredSTOContract,
+  PercentageTransferManagerContract,
+  EtherDividendCheckpointContract,
 } from '@polymathnetwork/abi-wrappers';
 import ERC20TokenWrapper from '../erc20_wrapper';
 import {
@@ -3569,7 +3569,7 @@ describe('SecurityTokenWrapper', () => {
         safetyFactor: 10,
       };
 
-      const iCtmFace = new ethers.utils.Interface(CountTransferManager.abi);
+      const iCtmFace = new ethers.utils.Interface(CountTransferManagerContract.ABI());
       const ctmData = iCtmFace.functions.configure.encode([mockedCtmParams.data.maxHolderCount]);
 
       when(
@@ -3762,7 +3762,7 @@ describe('SecurityTokenWrapper', () => {
         safetyFactor: 10,
       };
 
-      const iCtmFace = new ethers.utils.Interface(CountTransferManager.abi);
+      const iCtmFace = new ethers.utils.Interface(CountTransferManagerContract.ABI());
       const ctmData = iCtmFace.functions.configure.encode([mockedCtmParams.data.maxHolderCount]);
 
       when(
@@ -3950,7 +3950,7 @@ describe('SecurityTokenWrapper', () => {
         safetyFactor: 10,
       };
 
-      const iPtmFace = new ethers.utils.Interface(PercentageTransferManager.abi);
+      const iPtmFace = new ethers.utils.Interface(PercentageTransferManagerContract.ABI());
       const ptmData = iPtmFace.functions.configure.encode([
         valueToWei(mockedPtmParams.data.maxHolderPercentage, PERCENTAGE_DECIMALS).toString(),
         mockedPtmParams.data.allowPrimaryIssuance,
@@ -4146,7 +4146,7 @@ describe('SecurityTokenWrapper', () => {
         safetyFactor: 10,
       };
 
-      const iCappedFace = new ethers.utils.Interface(CappedSTO.abi);
+      const iCappedFace = new ethers.utils.Interface(CappedSTOContract.ABI());
       const cappedData = iCappedFace.functions.configure.encode([
         dateToBigNumber(mockedCappedParams.data.startTime).toNumber(),
         dateToBigNumber(mockedCappedParams.data.endTime).toNumber(),
@@ -4356,7 +4356,7 @@ describe('SecurityTokenWrapper', () => {
         safetyFactor: 10,
       };
 
-      const iUsdTieredStoFace = new ethers.utils.Interface(USDTieredSTO.abi);
+      const iUsdTieredStoFace = new ethers.utils.Interface(USDTieredSTOContract.ABI());
       const usdTieredStoData = iUsdTieredStoFace.functions.configure.encode([
         dateToBigNumber(mockedUsdTieredStoParams.data.startTime).toNumber(),
         dateToBigNumber(mockedUsdTieredStoParams.data.endTime).toNumber(),
@@ -4575,7 +4575,7 @@ describe('SecurityTokenWrapper', () => {
         safetyFactor: 10,
       };
 
-      const iErc20DividendFace = new ethers.utils.Interface(ERC20DividendCheckpoint.abi);
+      const iErc20DividendFace = new ethers.utils.Interface(ERC20DividendCheckpointContract.ABI());
       const erc20DividendData = iErc20DividendFace.functions.configure.encode([mockedErc20DividendParams.data.wallet]);
 
       when(
@@ -4762,7 +4762,7 @@ describe('SecurityTokenWrapper', () => {
         safetyFactor: 10,
       };
 
-      const iEtherDividendFace = new ethers.utils.Interface(EtherDividendCheckpoint.abi);
+      const iEtherDividendFace = new ethers.utils.Interface(EtherDividendCheckpointContract.ABI());
       const etherDividendData = iEtherDividendFace.functions.configure.encode([mockedEtherDividendParams.data.wallet]);
 
       when(

--- a/src/contract_wrappers/tokens/alternative_erc20_wrapper.ts
+++ b/src/contract_wrappers/tokens/alternative_erc20_wrapper.ts
@@ -2,25 +2,18 @@ import {
   ERC20DetailedContract,
   ERC20DetailedEventArgs,
   ERC20DetailedEvents,
-  ERC20Detailed,
   LogWithDecodedArgs,
   Web3Wrapper,
-  ContractAbi,
 } from '@polymathnetwork/abi-wrappers';
 import { schemas } from '@0x/json-schemas';
 import { bytes32ToString } from '../../utils/convert';
 import ERC20TokenWrapper from './erc20_wrapper';
 import { GetLogs, GetLogsAsyncParams, Subscribe, SubscribeAsyncParams } from '../../types';
 import assert from '../../utils/assert';
-
-import _ = require('lodash');
-
 /**
  * This class includes the functionality related to interacting with the AlternativeERC20 contract.
  */
 export default class AlternativeERC20Wrapper extends ERC20TokenWrapper {
-  public abi: ContractAbi = ERC20Detailed.abi;
-
   protected contract: Promise<ERC20DetailedContract>;
 
   /**
@@ -71,13 +64,12 @@ export default class AlternativeERC20Wrapper extends ERC20TokenWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      ERC20Detailed.abi,
       params.callback,
-      !_.isUndefined(params.isVerbose),
+      params.isVerbose,
     );
     return subscriptionToken;
   };
@@ -94,7 +86,6 @@ export default class AlternativeERC20Wrapper extends ERC20TokenWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      ERC20Detailed.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/tokens/erc20_detailed_wrapper.ts
+++ b/src/contract_wrappers/tokens/erc20_detailed_wrapper.ts
@@ -2,10 +2,8 @@ import {
   ERC20DetailedContract,
   ERC20DetailedEventArgs,
   ERC20DetailedEvents,
-  ERC20Detailed,
   LogWithDecodedArgs,
   Web3Wrapper,
-  ContractAbi,
 } from '@polymathnetwork/abi-wrappers';
 import { schemas } from '@0x/json-schemas';
 import ERC20TokenWrapper from './erc20_wrapper';
@@ -13,14 +11,10 @@ import { GetLogs, GetLogsAsyncParams, Subscribe, SubscribeAsyncParams } from '..
 
 import assert from '../../utils/assert';
 
-import _ = require('lodash');
-
 /**
  * This class includes the functionality related to interacting with the AlternativeERC20 contract.
  */
 export default class ERC20DetailedWrapper extends ERC20TokenWrapper {
-  public abi: ContractAbi = ERC20Detailed.abi;
-
   protected contract: Promise<ERC20DetailedContract>;
 
   /**
@@ -40,13 +34,12 @@ export default class ERC20DetailedWrapper extends ERC20TokenWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      ERC20Detailed.abi,
       params.callback,
-      !_.isUndefined(params.isVerbose),
+      params.isVerbose,
     );
     return subscriptionToken;
   };
@@ -63,7 +56,6 @@ export default class ERC20DetailedWrapper extends ERC20TokenWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      ERC20Detailed.abi,
     );
     return logs;
   };

--- a/src/contract_wrappers/tokens/poly_token_faucet_wrapper.ts
+++ b/src/contract_wrappers/tokens/poly_token_faucet_wrapper.ts
@@ -1,10 +1,4 @@
-import {
-  PolyTokenFaucetContract,
-  PolyTokenFaucet,
-  Web3Wrapper,
-  ContractAbi,
-  BigNumber,
-} from '@polymathnetwork/abi-wrappers';
+import { PolyTokenFaucetContract, Web3Wrapper, BigNumber } from '@polymathnetwork/abi-wrappers';
 import ContractWrapper from '../contract_wrapper';
 import { TxParams } from '../../types';
 import assert from '../../utils/assert';
@@ -21,8 +15,6 @@ interface GetTokensParams extends TxParams {
  * This class includes the functionality related to interacting with the PolyTokenFaucet contract.
  */
 export default class PolyTokenFaucetWrapper extends ContractWrapper {
-  public abi: ContractAbi = PolyTokenFaucet.abi;
-
   protected contract: Promise<PolyTokenFaucetContract>;
 
   /**

--- a/src/contract_wrappers/tokens/poly_token_wrapper.ts
+++ b/src/contract_wrappers/tokens/poly_token_wrapper.ts
@@ -4,13 +4,10 @@ import {
   PolyTokenEvents,
   PolyTokenTransferEventArgs,
   PolyTokenApprovalEventArgs,
-  PolyToken,
   Web3Wrapper,
-  ContractAbi,
   LogWithDecodedArgs,
   BigNumber,
 } from '@polymathnetwork/abi-wrappers';
-import _ from 'lodash';
 import { schemas } from '@0x/json-schemas';
 import { TxParams, GetLogsAsyncParams, SubscribeAsyncParams, EventCallback, Subscribe, GetLogs } from '../../types';
 import assert from '../../utils/assert';
@@ -58,8 +55,6 @@ interface ChangeApprovalParams extends TxParams {
  * This class includes the functionality related to interacting with the PolyToken contract.
  */
 export default class PolyTokenWrapper extends ERC20TokenWrapper {
-  public abi: ContractAbi = PolyToken.abi;
-
   protected contract: Promise<PolyTokenContract>;
 
   /**
@@ -108,13 +103,12 @@ export default class PolyTokenWrapper extends ERC20TokenWrapper {
     assert.doesConformToSchema('indexFilterValues', params.indexFilterValues, schemas.indexFilterValuesSchema);
     assert.isFunction('callback', params.callback);
     const normalizedContractAddress = (await this.contract).address.toLowerCase();
-    const subscriptionToken = this.subscribeInternal<ArgsType>(
+    const subscriptionToken = await this.subscribeInternal<ArgsType>(
       normalizedContractAddress,
       params.eventName,
       params.indexFilterValues,
-      PolyToken.abi,
       params.callback,
-      !_.isUndefined(params.isVerbose),
+      params.isVerbose,
     );
     return subscriptionToken;
   };
@@ -135,7 +129,6 @@ export default class PolyTokenWrapper extends ERC20TokenWrapper {
       params.eventName,
       params.blockRange,
       params.indexFilterValues,
-      PolyToken.abi,
     );
     return logs;
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,10 +695,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@polymathnetwork/abi-wrappers@3.0.0-beta.7":
-  version "3.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@polymathnetwork/abi-wrappers/-/abi-wrappers-3.0.0-beta.7.tgz#83b556dfedebc6a03e99144fc1e5b6ff89463c80"
-  integrity sha512-ZRGPI+ZaakRwTrnFuEy20LpPs1ZGpk6jhKK2lFkJ8DXs817ZIslltuWmUq6CnI6jc8o1Y6vpOc5Sxz+0pW0U+A==
+"@polymathnetwork/abi-wrappers@3.0.0-beta.8":
+  version "3.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@polymathnetwork/abi-wrappers/-/abi-wrappers-3.0.0-beta.8.tgz#48cad54a81695ef0ecd55dead7d5901cbd22b545"
+  integrity sha512-7IQgGmQi2O5Ta3Ue397n/q8Jgrr6dIf6sUGAP1cwXUiOLZedmsTzHXwGmQcrsdX++8Hav2P35jh6XH0n7rh+3g==
   dependencies:
     "@0x/base-contract" "^5.1.1"
     "@0x/utils" "^4.4.0"


### PR DESCRIPTION
ABIs are taken from each contract-wrapper so duplicated events are not
present