### PR TITLE
fix: 🐛 use correct hashing function for fee type

### DIFF
--- a/src/contract_wrappers/registries/__tests__/security_token_registry_wrapper.test.ts
+++ b/src/contract_wrappers/registries/__tests__/security_token_registry_wrapper.test.ts
@@ -18,7 +18,7 @@ import {
   weiToValue,
   valueToWei,
   packVersion,
-  stringToBytes32,
+  stringToKeccak256,
 } from '../../../utils/convert';
 import { MockedCallMethod, MockedSendMethod, getMockedPolyResponse } from '../../../test_utils/mocked_methods';
 import { FULL_DECIMALS, FeeType } from '../../../types';
@@ -881,13 +881,13 @@ describe('SecurityTokenRegistryWrapper', () => {
       const mockedParams = {
         feeType: FeeType.TickerRegFee,
       };
-      const bytes32 = stringToBytes32('tickerRegFee');
+      const keccak256 = stringToKeccak256('tickerRegFee');
       // Mocked method
       const mockedMethod = mock(MockedSendMethod);
       // Stub the method
       when(mockedContract.getFees).thenReturn(instance(mockedMethod));
       // Stub the request
-      when(mockedMethod.callAsync(objectContaining(bytes32))).thenResolve(expectedResult);
+      when(mockedMethod.callAsync(objectContaining(keccak256))).thenResolve(expectedResult);
 
       // Real call
       const result = await target.getFees(mockedParams);
@@ -895,7 +895,7 @@ describe('SecurityTokenRegistryWrapper', () => {
       expect(result).toEqual(expectedResult);
       // Verifications
       verify(mockedContract.getFees).once();
-      verify(mockedMethod.callAsync(objectContaining(bytes32))).once();
+      verify(mockedMethod.callAsync(objectContaining(keccak256))).once();
     });
   });
 

--- a/src/contract_wrappers/registries/security_token_registry_wrapper.ts
+++ b/src/contract_wrappers/registries/security_token_registry_wrapper.ts
@@ -45,7 +45,7 @@ import {
   weiToValue,
   valueToWei,
   packVersion,
-  stringToBytes32,
+  stringToKeccak256,
 } from '../../utils/convert';
 import functionsUtils from '../../utils/functions_utils';
 
@@ -1213,8 +1213,8 @@ export default class SecurityTokenRegistryWrapper extends ContractWrapper {
     if (![FeeType.StLaunchFee, FeeType.TickerRegFee].includes(feeType)) {
       assert.assert(false, ErrorCode.InvalidData, 'Incorrect fee type');
     }
-    const feeTypeBytes32 = stringToBytes32(params.feeType);
-    return (await this.contract).getFees.callAsync(feeTypeBytes32);
+    const feeTypeKeccak256 = stringToKeccak256(params.feeType);
+    return (await this.contract).getFees.callAsync(feeTypeKeccak256);
   };
 
   /**

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -9,7 +9,11 @@ export function bytes32ToString(value: string): string {
 }
 
 export function stringToBytes32(value: string): string {
-  return ethers.utils.formatBytes32String(value);
+  return ethers.utils.formatBytes32String(value);  
+}
+
+export function stringToKeccak256(value: string): string {
+  return ethers.utils.id(value);
 }
 
 export function checksumAddress(value: string): string {


### PR DESCRIPTION
The fee type was being passed as bytes32 when it should have been
keccak256