### PR TITLE
fix: 🐛 remake valid module check to support archived modules

### DIFF
--- a/src/contract_wrappers/modules/module_wrapper/common.ts
+++ b/src/contract_wrappers/modules/module_wrapper/common.ts
@@ -186,8 +186,9 @@ export default abstract class ModuleCommon extends ContractWrapper {
     }
 
     const address = await this.address();
-    const result = await (await this.securityTokenContract()).isModule.callAsync(address, types[0]);
-    return result;
+    // if the module doesn't exist, the data returned by this call will be empty (i.e. the name would be an empty string)
+    const [name] = await (await this.securityTokenContract()).getModule.callAsync(address);
+    return name !== '';
   };
 
   public isCallerTheSecurityTokenOwner = async (txData: Partial<TxData> | undefined): Promise<boolean> => {


### PR DESCRIPTION
Checking for validity in unarchived modules was throwing an error
because `isModule` in the ST contract returns false for archived modules