### PR TITLE
fix: 🐛 Delegate details return type

### DIFF
--- a/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper/__tests__/3.0.0.test.ts
+++ b/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper/__tests__/3.0.0.test.ts
@@ -123,7 +123,7 @@ describe('GeneralPermissionManagerWrapper', () => {
       // Stub the method
       when(mockedContract.delegateDetails).thenReturn(instance(mockedMethod));
       // Stub the request
-      when(mockedMethod.callAsync(params.delegate)).thenResolve(expectedResult);
+      when(mockedMethod.callAsync(params.delegate)).thenResolve(stringToBytes32(expectedResult));
 
       // Real call
       const result = await target.delegateDetails(params);

--- a/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper/__tests__/common.test.ts
+++ b/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper/__tests__/common.test.ts
@@ -137,7 +137,7 @@ describe('GeneralPermissionManagerWrapper', () => {
       // Stub the method
       when(mockedContract.delegateDetails).thenReturn(instance(mockedMethod));
       // Stub the request
-      when(mockedMethod.callAsync(params.delegate)).thenResolve(expectedResult);
+      when(mockedMethod.callAsync(params.delegate)).thenResolve(stringToBytes32(expectedResult));
 
       // Real call
       const result = await target.delegateDetails(params);

--- a/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper/common.ts
+++ b/src/contract_wrappers/modules/permission_manager/general_permission_manager_wrapper/common.ts
@@ -31,6 +31,7 @@ import {
   stringToBytes32,
   stringArrayToBytes32Array,
   parsePermBytes32Value,
+  bytes32ToString,
 } from '../../../../utils/convert';
 import ContractWrapper from '../../../contract_wrapper';
 
@@ -223,7 +224,8 @@ export default abstract class GeneralPermissionManagerCommon extends ModuleCommo
    */
   public delegateDetails = async (params: DelegateParams): Promise<string> => {
     assert.isETHAddressHex('delegate', params.delegate);
-    return (await this.contract).delegateDetails.callAsync(params.delegate);
+    const delegateDetails = await (await this.contract).delegateDetails.callAsync(params.delegate);
+    return bytes32ToString(delegateDetails);
   };
 
   /**


### PR DESCRIPTION
Delegate details were in bytes, must be decoded before returning it