### PR TITLE
feat: 🎸 usd tiered sto with capability to support stablecoins

### DIFF
--- a/examples/usdTieredSTO.ts
+++ b/examples/usdTieredSTO.ts
@@ -26,10 +26,12 @@ export const usdTieredSTO = async (polymathAPI: PolymathAPI, ticker: string) => 
     tokensPerTierDiscountPoly: [new BigNumber(8), new BigNumber(8)],
     nonAccreditedLimitUSD: new BigNumber(5),
     minimumInvestmentUSD: new BigNumber(5),
-    fundRaiseTypes: [FundRaiseType.ETH, FundRaiseType.POLY],
+    fundRaiseTypes: [FundRaiseType.StableCoin],
     wallet: '0x3333333333333333333333333333333333333333',
     treasuryWallet: '0x5555555555555555555555555555555555555555',
-    usdTokens: ['0x6666666666666666666666666666666666666666', '0x4444444444444444444444444444444444444444'],
+    stableTokens: ['0x6666666666666666666666666666666666666666', '0x4444444444444444444444444444444444444444'],
+    customOracleAddresses: ['0x1666666666666666666666666666666666666666', '0x1444444444444444444444444444444444444444'],
+    denominatedCurrency: 'USDC',
   };
   const options: AddingModuleOpts = {
     data: usdTieredSTOData,

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@0x/subproviders": "5.0.4",
     "@0x/types": "2.4.3",
     "@0x/typescript-typings": "4.3.0",
-    "@polymathnetwork/abi-wrappers": "4.0.0-beta.8",
+    "@polymathnetwork/abi-wrappers": "4.0.0-beta.9",
     "@types/bluebird": "^3.5.27",
     "@types/semver": "^6.0.1",
     "bluebird": "^3.5.5",

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.0.0.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.0.0.ts
@@ -7,8 +7,8 @@ import ContractFactory from '../../../../factories/contractFactory';
 import { WithSTO_3_0_0 } from '../sto_wrapper';
 
 /**
- * @param nonAccreditedLimitUSD max non accredited invets limit
- * @param minimumInvestmentUSD overall minimum investment limit
+ * @param fundRaiseType Actual currency
+ * @param oracleAddress Address of the oracle
  */
 export interface ModifyOracleParams extends TxParams {
   fundRaiseType: FundRaiseType;

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.0.0.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.0.0.ts
@@ -1,10 +1,19 @@
-import { USDTieredSTOContract_3_0_0, BigNumber, Web3Wrapper } from '@polymathnetwork/abi-wrappers';
+import { USDTieredSTOContract_3_0_0, BigNumber, Web3Wrapper, PolyResponse } from '@polymathnetwork/abi-wrappers';
 import USDTieredSTOCommon, { TierIndexParams } from './common';
 import assert from '../../../../utils/assert';
-import { ErrorCode, ContractVersion, TxParams, FULL_DECIMALS, Constructor } from '../../../../types';
+import { ErrorCode, ContractVersion, TxParams, FULL_DECIMALS, Constructor, FundRaiseType } from '../../../../types';
 import { numberToBigNumber, weiToValue } from '../../../../utils/convert';
 import ContractFactory from '../../../../factories/contractFactory';
 import { WithSTO_3_0_0 } from '../sto_wrapper';
+
+/**
+ * @param nonAccreditedLimitUSD max non accredited invets limit
+ * @param minimumInvestmentUSD overall minimum investment limit
+ */
+export interface ModifyOracleParams extends TxParams {
+  fundRaiseType: FundRaiseType;
+  oracleAddress: string;
+}
 
 interface MintedByTier {
   mintedInETH: BigNumber;
@@ -124,6 +133,28 @@ export class USDTieredSTO_3_0_0 extends USDTieredSTOBase_3_0_0 {
     assert.assert(!(await this.isFinalized()), ErrorCode.PreconditionRequired, 'STO is already finalized');
     // we can't execute mint to validate the method
     return (await this.contract).finalize.sendTransactionAsync(params.txData, params.safetyFactor);
+  };
+
+  /**
+   * Modifies oracle
+   */
+  public modifyOracle = async (params: ModifyOracleParams): Promise<PolyResponse> => {
+    assert.assert(
+      await this.isCallerTheSecurityTokenOwner(params.txData),
+      ErrorCode.Unauthorized,
+      'The caller must be the ST owner',
+    );
+    assert.assert(
+      params.fundRaiseType === FundRaiseType.POLY || params.fundRaiseType === FundRaiseType.ETH,
+      ErrorCode.InvalidData,
+      'Invalid currency',
+    );
+    return (await this.contract).modifyOracle.sendTransactionAsync(
+      params.fundRaiseType,
+      params.oracleAddress,
+      params.txData,
+      params.safetyFactor,
+    );
   };
 }
 

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.1.0.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.1.0.ts
@@ -36,7 +36,6 @@ import {
   bigNumberToDate,
   weiArrayToValueArray,
   stringToBytes32,
-  stringArrayToBytes32Array,
   bytes32ToString,
 } from '../../../../utils/convert';
 import ContractFactory from '../../../../factories/contractFactory';

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.1.0.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.1.0.ts
@@ -289,9 +289,8 @@ export class USDTieredSTO_3_1_0 extends USDTieredSTOBase_3_1_0 {
     );
 
     if ((await this.denominatedCurrency()) !== params.denominatedCurrencySymbol) {
-      assert.assert(
-        (await this.startTime()) >= new Date(),
-        ErrorCode.PreconditionRequired,
+      assert.isFutureDate(
+        await this.startTime(),
         "The denominated currency can change only if the STO hasn't started yet",
       );
     }
@@ -300,12 +299,12 @@ export class USDTieredSTO_3_1_0 extends USDTieredSTOBase_3_1_0 {
       assert.assert(
         params.denominatedCurrencySymbol !== '',
         ErrorCode.InvalidData,
-        'Invalid denominatedCurrencySymbol',
+        'Denominated currency symbol can not be empty',
       );
       assert.assert(
         params.customOracleAddresses.length === 2,
         ErrorCode.InvalidLength,
-        'Invalid customOracleAddresses length',
+        'Custom oracle addresses array must have two values',
       );
 
       if (await this.fundRaiseTypes({ type: FundRaiseType.ETH })) {

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.1.0.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/3.1.0.ts
@@ -309,15 +309,15 @@ export class USDTieredSTO_3_1_0 extends USDTieredSTOBase_3_1_0 {
       );
 
       if (await this.fundRaiseTypes({ type: FundRaiseType.ETH })) {
-        assert.isNonZeroETHAddressHex('customOracleAddresses[0]', params.customOracleAddresses[0]);
+        assert.isNonZeroETHAddressHex('ETH Oracle Address', params.customOracleAddresses[0]);
       }
 
       if (await this.fundRaiseTypes({ type: FundRaiseType.POLY })) {
-        assert.isNonZeroETHAddressHex('customOracleAddresses[1]', params.customOracleAddresses[1]);
+        assert.isNonZeroETHAddressHex('POLY Oracle Address', params.customOracleAddresses[1]);
       }
     } else {
       assert.assert(
-        params.denominatedCurrencySymbol !== '',
+        params.denominatedCurrencySymbol === '',
         ErrorCode.InvalidData,
         'Invalid denominatedCurrencySymbol',
       );

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/3.0.0.test.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/3.0.0.test.ts
@@ -12,9 +12,9 @@ import USDTieredSTOCommon from '../common';
 import { USDTieredSTO_3_0_0 } from '../3.0.0';
 import ContractFactory from '../../../../../factories/contractFactory';
 import { weiToValue } from '../../../../../utils/convert';
-import { FULL_DECIMALS } from '../../../../../types';
+import { FULL_DECIMALS, FundRaiseType } from '../../../../../types';
 
-describe('USD Tiered STO 3.0.0', () => {  
+describe('USD Tiered STO 3.0.0', () => {
   let target: USDTieredSTO_3_0_0;
   let mockedWrapper: Web3Wrapper;
   let mockedContract: USDTieredSTOContract_3_0_0;
@@ -314,6 +314,72 @@ describe('USD Tiered STO 3.0.0', () => {
       verify(mockedSecurityTokenContract.owner).once();
       verify(mockedContract.isFinalized).once();
       verify(mockedIsFinalizedMethod.callAsync()).once();
+      verify(mockedWrapper.getAvailableAddressesAsync()).once();
+    });
+  });
+
+  describe('ModifyOracle', () => {
+    test('should modifyOracle', async () => {
+      // Mock Only Owner and Security Token
+      const expectedOwnerResult = '0x5555555555555555555555555555555555555555';
+      // Security Token Address expected
+      const expectedSecurityTokenAddress = '0x3333333333333333333333333333333333333333';
+      // Setup get Security Token Address
+      const mockedGetSecurityTokenAddressMethod = mock(MockedCallMethod);
+      when(mockedContract.securityToken).thenReturn(instance(mockedGetSecurityTokenAddressMethod));
+      when(mockedGetSecurityTokenAddressMethod.callAsync()).thenResolve(expectedSecurityTokenAddress);
+      when(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).thenResolve(
+        instance(mockedSecurityTokenContract),
+      );
+      const mockedSecurityTokenOwnerMethod = mock(MockedCallMethod);
+      when(mockedSecurityTokenOwnerMethod.callAsync()).thenResolve(expectedOwnerResult);
+      when(mockedSecurityTokenContract.owner).thenReturn(instance(mockedSecurityTokenOwnerMethod));
+
+      // Mock web3 wrapper owner
+      when(mockedWrapper.getAvailableAddressesAsync()).thenResolve([expectedOwnerResult]);
+
+      const mockedParams = {
+        oracleAddress: '0x1111111111111111111111111111111111111111',
+        fundRaiseType: FundRaiseType.ETH,
+        txData: {},
+        safetyFactor: 10,
+      };
+
+      const expectedResult = getMockedPolyResponse();
+      // Mocked method
+      const mockedMethod = mock(MockedSendMethod);
+      // Stub the method
+      when(mockedContract.modifyOracle).thenReturn(instance(mockedMethod));
+      // Stub the request
+      when(
+        mockedMethod.sendTransactionAsync(
+          mockedParams.fundRaiseType,
+          mockedParams.oracleAddress,
+          mockedParams.txData,
+          mockedParams.safetyFactor,
+        ),
+      ).thenResolve(expectedResult);
+
+      // Real call
+      const result = await target.modifyOracle(mockedParams);
+
+      // Result expectation
+      expect(result).toBe(expectedResult);
+      // Verifications
+      verify(mockedContract.modifyOracle).once();
+      verify(
+        mockedMethod.sendTransactionAsync(
+          mockedParams.fundRaiseType,
+          mockedParams.oracleAddress,
+          mockedParams.txData,
+          mockedParams.safetyFactor,
+        ),
+      ).once();
+      verify(mockedContract.securityToken).once();
+      verify(mockedGetSecurityTokenAddressMethod.callAsync()).once();
+      verify(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).once();
+      verify(mockedSecurityTokenOwnerMethod.callAsync()).once();
+      verify(mockedSecurityTokenContract.owner).once();
       verify(mockedWrapper.getAvailableAddressesAsync()).once();
     });
   });

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/3.1.0.test.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/3.1.0.test.ts
@@ -67,7 +67,7 @@ describe('USD Tiered STO 3.1.0', () => {
       when(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).thenResolve(
         instance(mockedSecurityTokenContract),
       );
-      const expectedDecimalsResult = new BigNumber(18);
+      const expectedDecimalsResult = FULL_DECIMALS;
       const mockedDecimalsMethod = mock(MockedCallMethod);
       when(mockedSecurityTokenContract.decimals).thenReturn(instance(mockedDecimalsMethod));
       when(mockedDecimalsMethod.callAsync()).thenResolve(expectedDecimalsResult);
@@ -129,7 +129,7 @@ describe('USD Tiered STO 3.1.0', () => {
       when(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).thenResolve(
         instance(mockedSecurityTokenContract),
       );
-      const expectedDecimalsResult = new BigNumber(18);
+      const expectedDecimalsResult = FULL_DECIMALS;
       const mockedDecimalsMethod = mock(MockedCallMethod);
       when(mockedSecurityTokenContract.decimals).thenReturn(instance(mockedDecimalsMethod));
       when(mockedDecimalsMethod.callAsync()).thenResolve(expectedDecimalsResult);
@@ -178,7 +178,7 @@ describe('USD Tiered STO 3.1.0', () => {
       when(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).thenResolve(
         instance(mockedSecurityTokenContract),
       );
-      const expectedDecimalsResult = new BigNumber(18);
+      const expectedDecimalsResult = FULL_DECIMALS;
       const mockedDecimalsMethod = mock(MockedCallMethod);
       when(mockedSecurityTokenContract.decimals).thenReturn(instance(mockedDecimalsMethod));
       when(mockedDecimalsMethod.callAsync()).thenResolve(expectedDecimalsResult);
@@ -249,7 +249,7 @@ describe('USD Tiered STO 3.1.0', () => {
       when(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).thenResolve(
         instance(mockedSecurityTokenContract),
       );
-      const expectedDecimalsResult = new BigNumber(18);
+      const expectedDecimalsResult = FULL_DECIMALS;
       const mockedDecimalsMethod = mock(MockedCallMethod);
       when(mockedSecurityTokenContract.decimals).thenReturn(instance(mockedDecimalsMethod));
       when(mockedDecimalsMethod.callAsync()).thenResolve(expectedDecimalsResult);
@@ -350,7 +350,7 @@ describe('USD Tiered STO 3.1.0', () => {
       when(mockedDenominatedCurrencyMethod.callAsync()).thenResolve(expectedDenominatedCurrencyResult);
 
       // startTime mock
-      const expectedStartTimeResult = new BigNumber(3876536279);
+      const expectedStartTimeResult = dateToBigNumber(new Date(2022, 11, 11));
       const mockedStartTimeMethod = mock(MockedCallMethod);
       when(mockedContract.startTime).thenReturn(instance(mockedStartTimeMethod));
       when(mockedStartTimeMethod.callAsync()).thenResolve(expectedStartTimeResult);

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/3.1.0.test.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/3.1.0.test.ts
@@ -335,7 +335,7 @@ describe('USD Tiered STO 3.1.0', () => {
           '0x1111111111111111111111111111111111111111',
           '0x2221111111111111111111111111111111111111',
         ],
-        denominatedCurrencySymbol: 'DAI',
+        denominatedCurrencySymbol: 'CAD',
         txData: {},
         safetyFactor: 10,
       };
@@ -344,7 +344,7 @@ describe('USD Tiered STO 3.1.0', () => {
       const mockedMethod = mock(MockedSendMethod);
 
       // denominatedCurrency mock
-      const expectedDenominatedCurrencyResult = stringToBytes32('USDT');
+      const expectedDenominatedCurrencyResult = stringToBytes32('USD');
       const mockedDenominatedCurrencyMethod = mock(MockedCallMethod);
       when(mockedContract.denominatedCurrency).thenReturn(instance(mockedDenominatedCurrencyMethod));
       when(mockedDenominatedCurrencyMethod.callAsync()).thenResolve(expectedDenominatedCurrencyResult);

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/common.test.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/__tests__/common.test.ts
@@ -2186,72 +2186,6 @@ describe('USD Tiered STO Common', () => {
     });
   });
 
-  describe('ModifyOracle', () => {
-    test('should modifyOracle', async () => {
-      // Mock Only Owner and Security Token
-      const expectedOwnerResult = '0x5555555555555555555555555555555555555555';
-      // Security Token Address expected
-      const expectedSecurityTokenAddress = '0x3333333333333333333333333333333333333333';
-      // Setup get Security Token Address
-      const mockedGetSecurityTokenAddressMethod = mock(MockedCallMethod);
-      when(mockedContract.securityToken).thenReturn(instance(mockedGetSecurityTokenAddressMethod));
-      when(mockedGetSecurityTokenAddressMethod.callAsync()).thenResolve(expectedSecurityTokenAddress);
-      when(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).thenResolve(
-        instance(mockedSecurityTokenContract),
-      );
-      const mockedSecurityTokenOwnerMethod = mock(MockedCallMethod);
-      when(mockedSecurityTokenOwnerMethod.callAsync()).thenResolve(expectedOwnerResult);
-      when(mockedSecurityTokenContract.owner).thenReturn(instance(mockedSecurityTokenOwnerMethod));
-
-      // Mock web3 wrapper owner
-      when(mockedWrapper.getAvailableAddressesAsync()).thenResolve([expectedOwnerResult]);
-
-      const mockedParams = {
-        oracleAddress: '0x1111111111111111111111111111111111111111',
-        fundRaiseType: FundRaiseType.ETH,
-        txData: {},
-        safetyFactor: 10,
-      };
-
-      const expectedResult = getMockedPolyResponse();
-      // Mocked method
-      const mockedMethod = mock(MockedSendMethod);
-      // Stub the method
-      when(mockedContract.modifyOracle).thenReturn(instance(mockedMethod));
-      // Stub the request
-      when(
-        mockedMethod.sendTransactionAsync(
-          mockedParams.fundRaiseType,
-          mockedParams.oracleAddress,
-          mockedParams.txData,
-          mockedParams.safetyFactor,
-        ),
-      ).thenResolve(expectedResult);
-
-      // Real call
-      const result = await target.modifyOracle(mockedParams);
-
-      // Result expectation
-      expect(result).toBe(expectedResult);
-      // Verifications
-      verify(mockedContract.modifyOracle).once();
-      verify(
-        mockedMethod.sendTransactionAsync(
-          mockedParams.fundRaiseType,
-          mockedParams.oracleAddress,
-          mockedParams.txData,
-          mockedParams.safetyFactor,
-        ),
-      ).once();
-      verify(mockedContract.securityToken).once();
-      verify(mockedGetSecurityTokenAddressMethod.callAsync()).once();
-      verify(mockedContractFactory.getSecurityTokenContract(expectedSecurityTokenAddress)).once();
-      verify(mockedSecurityTokenOwnerMethod.callAsync()).once();
-      verify(mockedSecurityTokenContract.owner).once();
-      verify(mockedWrapper.getAvailableAddressesAsync()).once();
-    });
-  });
-
   describe('ModifyLimits', () => {
     test('should modifyLimits', async () => {
       // Mock Only Owner and Security Token
@@ -2424,7 +2358,7 @@ describe('USD Tiered STO Common', () => {
       const mockedParams = {
         wallet: '0x1234567890123456789012345678901234567890',
         treasuryWallet: '0x0987654321098765432109876543210987654321',
-        usdTokens: ['0x9999999999999999999999999999999999999999', '0x8888888888888888888888888888888888888888'],
+        stableTokens: ['0x9999999999999999999999999999999999999999', '0x8888888888888888888888888888888888888888'],
         txData: {},
         safetyFactor: 10,
       };
@@ -2438,7 +2372,7 @@ describe('USD Tiered STO Common', () => {
         mockedMethod.sendTransactionAsync(
           mockedParams.wallet,
           mockedParams.treasuryWallet,
-          mockedParams.usdTokens,
+          mockedParams.stableTokens,
           mockedParams.txData,
           mockedParams.safetyFactor,
         ),
@@ -2455,7 +2389,7 @@ describe('USD Tiered STO Common', () => {
         mockedMethod.sendTransactionAsync(
           mockedParams.wallet,
           mockedParams.treasuryWallet,
-          mockedParams.usdTokens,
+          mockedParams.stableTokens,
           mockedParams.txData,
           mockedParams.safetyFactor,
         ),

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/common.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/common.ts
@@ -287,15 +287,6 @@ export interface ModifyLimitsParams extends TxParams {
 }
 
 /**
- * @param nonAccreditedLimitUSD max non accredited invets limit
- * @param minimumInvestmentUSD overall minimum investment limit
- */
-export interface ModifyOracleParams extends TxParams {
-  fundRaiseType: FundRaiseType;
-  oracleAddress: string;
-}
-
-/**
  * @param fundRaiseTypes Array of fund raise types to allow
  */
 export interface ModifyFundingParams extends TxParams {
@@ -305,12 +296,12 @@ export interface ModifyFundingParams extends TxParams {
 /**
  * @param wallet Address of wallet where funds are sent
  * @param treasuryWallet Address of wallet where unsold tokens are sent
- * @param usdTokens Address of usd tokens
+ * @param stableTokens Address of stable tokens
  */
 export interface ModifyAddressesParams extends TxParams {
   wallet: string;
   treasuryWallet: string;
-  usdTokens: string[];
+  stableTokens: string[];
 }
 
 /**
@@ -854,28 +845,6 @@ export default abstract class USDTieredSTOCommon extends STOCommon {
   };
 
   /**
-   * Modifies oracle
-   */
-  public modifyOracle = async (params: ModifyOracleParams): Promise<PolyResponse> => {
-    assert.assert(
-      await this.isCallerTheSecurityTokenOwner(params.txData),
-      ErrorCode.Unauthorized,
-      'The caller must be the ST owner',
-    );
-    assert.assert(
-      params.fundRaiseType === FundRaiseType.POLY || params.fundRaiseType === FundRaiseType.ETH,
-      ErrorCode.InvalidData,
-      'Invalid currency',
-    );
-    return (await this.contract).modifyOracle.sendTransactionAsync(
-      params.fundRaiseType,
-      params.oracleAddress,
-      params.txData,
-      params.safetyFactor,
-    );
-  };
-
-  /**
    * Modifies max non accredited investment limit and overall minimum investment limit
    */
   public modifyLimits = async (params: ModifyLimitsParams): Promise<PolyResponse> => {
@@ -919,13 +888,13 @@ export default abstract class USDTieredSTOCommon extends STOCommon {
       ErrorCode.Unauthorized,
       'The caller must be the ST owner',
     );
-    params.usdTokens.forEach(address => assert.isETHAddressHex('usdTokens', address));
+    params.stableTokens.forEach(address => assert.isETHAddressHex('stableTokens', address));
     assert.isNonZeroETHAddressHex('wallet', params.wallet);
     assert.isNonZeroETHAddressHex('treasuryWallet', params.treasuryWallet);
     return (await this.contract).modifyAddresses.sendTransactionAsync(
       params.wallet,
       params.treasuryWallet,
-      params.usdTokens,
+      params.stableTokens,
       params.txData,
       params.safetyFactor,
     );

--- a/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/index.ts
+++ b/src/contract_wrappers/modules/sto/usd_tiered_sto_wrapper/index.ts
@@ -3,18 +3,19 @@ import {
   USDTieredSTOEvents_3_1_0,
   USDTieredSTOEvents_3_0_0,
   USDTieredSTOEventArgs_3_0_0,
+  USDTieredSTOSetOraclesEventArgs_3_1_0,
+  USDTieredSTOUsageFeeDeductedEventArgs_3_1_0,
   USDTieredSTOAllowPreMintFlagEventArgs_3_1_0,
   USDTieredSTORevokePreMintFlagEventArgs_3_1_0,
   USDTieredSTOReserveTokenTransferEventArgs_3_1_0,
 } from '@polymathnetwork/abi-wrappers';
-import { USDTieredSTO_3_0_0, isUSDTieredSTO_3_0_0 } from './3.0.0';
-import { USDTieredSTO_3_1_0, isUSDTieredSTO_3_1_0 } from './3.1.0';
+import { USDTieredSTO_3_0_0, isUSDTieredSTO_3_0_0, ModifyOracleParams } from './3.0.0';
+import { USDTieredSTO_3_1_0, isUSDTieredSTO_3_1_0, ModifyOraclesParams, GetCustomOracleAddressParams } from './3.1.0';
 import Common, {
   isUSDTieredSTO,
   ChangeNonAccreditedLimitParams,
   ModifyTimesParams,
   ModifyLimitsParams,
-  ModifyOracleParams,
   ModifyFundingParams,
   ModifyAddressesParams,
   ModifyTiersParams,
@@ -36,6 +37,8 @@ export type USDTieredSTOEvents = USDTieredSTOEvents_3_0_0 | USDTieredSTOEvents_3
 
 export type USDTieredSTOEventArgs =
   | USDTieredSTOEventArgs_3_0_0
+  | USDTieredSTOSetOraclesEventArgs_3_1_0
+  | USDTieredSTOUsageFeeDeductedEventArgs_3_1_0
   | USDTieredSTOAllowPreMintFlagEventArgs_3_1_0
   | USDTieredSTORevokePreMintFlagEventArgs_3_1_0
   | USDTieredSTOReserveTokenTransferEventArgs_3_1_0;
@@ -57,6 +60,8 @@ export {
   USDTieredSTOAllowPreMintFlagEventArgs_3_1_0 as USDTieredSTOAllowPreMintFlagEventArgs,
   USDTieredSTORevokePreMintFlagEventArgs_3_1_0 as USDTieredSTORevokePreMintFlagEventArgs,
   USDTieredSTOReserveTokenTransferEventArgs_3_1_0 as USDTieredSTOReserveTokenTransferEventArgs,
+  USDTieredSTOSetOraclesEventArgs_3_1_0 as USDTieredSTOSetOraclesEventArgs,
+  USDTieredSTOUsageFeeDeductedEventArgs_3_1_0 as USDTieredSTOUsageFeeDeductedEventArgs,
 } from '@polymathnetwork/abi-wrappers';
 
 export type USDTieredSTO = USDTieredSTO_3_0_0 | USDTieredSTO_3_1_0;
@@ -67,7 +72,6 @@ export namespace USDTieredSTOTransactionParams {
   export interface ChangeNonAccreditedLimit extends ChangeNonAccreditedLimitParams {}
   export interface ModifyTimes extends ModifyTimesParams {}
   export interface ModifyLimits extends ModifyLimitsParams {}
-  export interface ModifyOracle extends ModifyOracleParams {}
   export interface ModifyFunding extends ModifyFundingParams {}
   export interface ModifyAddresses extends ModifyAddressesParams {}
   export interface ModifyTiers extends ModifyTiersParams {}
@@ -78,6 +82,9 @@ export namespace USDTieredSTOTransactionParams {
   export interface BuyWithPOLYRateLimited extends BuyWithPOLYRateLimitedParams {}
   export interface BuyWithUSD extends BuyWithUSDParams {}
   export interface BuyWithUSDRateLimited extends BuyWithUSDRateLimitedParams {}
+  export interface ModifyOracle extends ModifyOracleParams {}
+  export interface ModifyOracles extends ModifyOraclesParams {}
+  export interface GetCustomOracleAddress extends GetCustomOracleAddressParams {}
 }
 
 // for internal use

--- a/src/contract_wrappers/tokens/security_token_wrapper/__tests__/common.test.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper/__tests__/common.test.ts
@@ -4383,7 +4383,9 @@ describe('SecurityTokenCommon', () => {
         fundRaiseTypes: [FundRaiseType.StableCoin],
         wallet: '0x1111111111111111111111111111111111111111',
         treasuryWallet: '0x2222222222222222222222222222222222222222',
-        usdTokens: ['0x1111111111111111111111111111111111111111', '0x2222222222222222222222222222222222222222'],
+        stableTokens: ['0x1111111111111111111111111111111111111111', '0x2222222222222222222222222222222222222222'],
+        customOracleAddresses: ['0x2111111111111111111111111111111111111111', '0x3222222222222222222222222222222222222222'],
+        denominatedCurrency: 'USDC'
       };
       const mockedUsdTieredStoParams = {
         moduleName: ModuleName.UsdTieredSTO,
@@ -4417,7 +4419,9 @@ describe('SecurityTokenCommon', () => {
         mockedUsdTieredStoParams.data.fundRaiseTypes,
         mockedUsdTieredStoParams.data.wallet,
         mockedUsdTieredStoParams.data.treasuryWallet,
-        mockedUsdTieredStoParams.data.usdTokens,
+        mockedUsdTieredStoParams.data.stableTokens,
+        mockedUsdTieredStoParams.data.customOracleAddresses,
+        stringToBytes32(mockedUsdTieredStoParams.data.denominatedCurrency),
       ]);
 
       when(
@@ -4450,7 +4454,9 @@ describe('SecurityTokenCommon', () => {
           fundRaiseTypes: usdTieredStoParams.fundRaiseTypes,
           wallet: usdTieredStoParams.wallet,
           treasuryWallet: usdTieredStoParams.treasuryWallet,
-          usdTokens: usdTieredStoParams.usdTokens,
+          stableTokens: usdTieredStoParams.stableTokens,
+          customOracleAddresses: usdTieredStoParams.customOracleAddresses,
+          denominatedCurrency: usdTieredStoParams.denominatedCurrency
         },
         txData: mockedUsdTieredStoParams.txData,
         safetyFactor: mockedUsdTieredStoParams.safetyFactor,

--- a/src/contract_wrappers/tokens/security_token_wrapper/common.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper/common.ts
@@ -2446,16 +2446,18 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
     assert.isNonZeroETHAddressHex('Wallet', data.wallet);
     assert.isNonZeroETHAddressHex('ReserveWallet', data.treasuryWallet);
     data.stableTokens.forEach(address => assert.isNonZeroETHAddressHex('stableTokens', address));
-
     if (data.customOracleAddresses.length > 0) {
-      if (data.fundRaiseTypes[0] === FundRaiseType.ETH) {
-        assert.isNonZeroETHAddressHex('customOracleAddresses[0]', data.customOracleAddresses[0]);
+      const ETH = data.fundRaiseTypes.findIndex(fundRaiseType => {
+        return fundRaiseType === FundRaiseType.ETH;
+      });
+      const POLY = data.fundRaiseTypes.findIndex(fundRaiseType => {
+        return fundRaiseType === FundRaiseType.POLY;
+      });
+      if (ETH > -1) {
+        assert.isNonZeroETHAddressHex('ETH Oracle Address', data.customOracleAddresses[0]);
       }
-      if (data.fundRaiseTypes[1] === FundRaiseType.POLY) {
-        assert.isNonZeroETHAddressHex('customOracleAddresses[1]', data.customOracleAddresses[0]);
-      }
-      if (data.fundRaiseTypes[0] !== FundRaiseType.ETH && data.fundRaiseTypes[1] !== FundRaiseType.POLY) {
-        data.customOracleAddresses.forEach(address => assert.isNonZeroETHAddressHex('customOracleAddresses', address));
+      if (POLY > -1) {
+        assert.isNonZeroETHAddressHex('POLY Oracle Address', data.customOracleAddresses[1]);
       }
       assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Denominated Currency not provided');
       assert.assert(
@@ -2464,7 +2466,7 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
         'Invalid customOracleAddresses length',
       );
     } else {
-      assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Invalid denominatedCurrencySymbol');
+      assert.assert(data.denominatedCurrency === '', ErrorCode.InvalidData, 'Invalid denominatedCurrencySymbol');
     }
   };
 

--- a/src/contract_wrappers/tokens/security_token_wrapper/common.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper/common.ts
@@ -1034,7 +1034,9 @@ export interface USDTieredSTOData {
   fundRaiseTypes: FundRaiseType[];
   wallet: string;
   treasuryWallet: string;
-  usdTokens: string[];
+  stableTokens: string[];
+  customOracleAddresses: string[];
+  denominatedCurrency: string;
 }
 
 interface AddModuleInterface {
@@ -1615,7 +1617,7 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
     assert.assert(await this.isIssuable(), ErrorCode.PreconditionRequired, 'Issuance frozen');
     const canTransfer = await this.canTransfer({
       to: params.investor,
-      value: params.value,    
+      value: params.value,
     });
     assert.assert(
       canTransfer.statusCode !== TransferStatusCode.TransferFailure,
@@ -2179,7 +2181,7 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
       params.from,
       params.to,
       valueToWei(params.value, await this.decimals()),
-      stringToBytes32(params.data || ''),      
+      stringToBytes32(params.data || ''),
     );
     const status = this.getTransferStatusCode(result[0]);
     const typedResult: CanTransferFromData = {
@@ -2443,6 +2445,9 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
     );
     assert.isNonZeroETHAddressHex('Wallet', data.wallet);
     assert.isNonZeroETHAddressHex('ReserveWallet', data.treasuryWallet);
+    data.stableTokens.forEach(address => assert.isNonZeroETHAddressHex('stableTokens', address));
+    data.customOracleAddresses.forEach(address => assert.isNonZeroETHAddressHex('customOracleAddresses', address));
+    assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Denominated Currency not provided');
   };
 
   public async addModuleRequirementsAndGetData(params: AddModuleParams): Promise<ProduceAddModuleInformation> {
@@ -2517,7 +2522,9 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
           (params.data as USDTieredSTOData).fundRaiseTypes,
           (params.data as USDTieredSTOData).wallet,
           (params.data as USDTieredSTOData).treasuryWallet,
-          (params.data as USDTieredSTOData).usdTokens,
+          (params.data as USDTieredSTOData).stableTokens,
+          (params.data as USDTieredSTOData).customOracleAddresses,
+          stringToBytes32((params.data as USDTieredSTOData).denominatedCurrency),
         ]);
         break;
       case ModuleName.ERC20DividendCheckpoint:

--- a/src/contract_wrappers/tokens/security_token_wrapper/common.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper/common.ts
@@ -2446,8 +2446,25 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
     assert.isNonZeroETHAddressHex('Wallet', data.wallet);
     assert.isNonZeroETHAddressHex('ReserveWallet', data.treasuryWallet);
     data.stableTokens.forEach(address => assert.isNonZeroETHAddressHex('stableTokens', address));
-    data.customOracleAddresses.forEach(address => assert.isNonZeroETHAddressHex('customOracleAddresses', address));
-    assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Denominated Currency not provided');
+
+    if (data.customOracleAddresses.length > 0) {
+      if (data.fundRaiseTypes[0] === FundRaiseType.ETH) {
+        assert.isNonZeroETHAddressHex('customOracleAddresses[0]', data.customOracleAddresses[0]);
+      }
+      if (data.fundRaiseTypes[1] === FundRaiseType.POLY) {
+        assert.isNonZeroETHAddressHex('customOracleAddresses[1]', data.customOracleAddresses[0]);
+      } else {
+        data.customOracleAddresses.forEach(address => assert.isNonZeroETHAddressHex('customOracleAddresses', address));
+      }
+      assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Denominated Currency not provided');
+      assert.assert(
+        data.customOracleAddresses.length === 2,
+        ErrorCode.InvalidLength,
+        'Invalid customOracleAddresses length',
+      );
+    } else {
+      assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Invalid denominatedCurrencySymbol');
+    }
   };
 
   public async addModuleRequirementsAndGetData(params: AddModuleParams): Promise<ProduceAddModuleInformation> {

--- a/src/contract_wrappers/tokens/security_token_wrapper/common.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper/common.ts
@@ -2453,7 +2453,8 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
       }
       if (data.fundRaiseTypes[1] === FundRaiseType.POLY) {
         assert.isNonZeroETHAddressHex('customOracleAddresses[1]', data.customOracleAddresses[0]);
-      } else {
+      }
+      if (data.fundRaiseTypes[0] !== FundRaiseType.ETH && data.fundRaiseTypes[1] !== FundRaiseType.POLY) {
         data.customOracleAddresses.forEach(address => assert.isNonZeroETHAddressHex('customOracleAddresses', address));
       }
       assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Denominated Currency not provided');

--- a/src/contract_wrappers/tokens/security_token_wrapper/common.ts
+++ b/src/contract_wrappers/tokens/security_token_wrapper/common.ts
@@ -2447,16 +2447,10 @@ export default abstract class SecurityTokenCommon extends ERC20TokenWrapper {
     assert.isNonZeroETHAddressHex('ReserveWallet', data.treasuryWallet);
     data.stableTokens.forEach(address => assert.isNonZeroETHAddressHex('stableTokens', address));
     if (data.customOracleAddresses.length > 0) {
-      const ETH = data.fundRaiseTypes.findIndex(fundRaiseType => {
-        return fundRaiseType === FundRaiseType.ETH;
-      });
-      const POLY = data.fundRaiseTypes.findIndex(fundRaiseType => {
-        return fundRaiseType === FundRaiseType.POLY;
-      });
-      if (ETH > -1) {
+      if (data.fundRaiseTypes.includes(FundRaiseType.ETH)) {
         assert.isNonZeroETHAddressHex('ETH Oracle Address', data.customOracleAddresses[0]);
       }
-      if (POLY > -1) {
+      if (data.fundRaiseTypes.includes(FundRaiseType.POLY)) {
         assert.isNonZeroETHAddressHex('POLY Oracle Address', data.customOracleAddresses[1]);
       }
       assert.assert(data.denominatedCurrency !== '', ErrorCode.InvalidData, 'Denominated Currency not provided');

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,8 @@ export {
   USDTieredSTOSetTreasuryWalletEventArgs,
   USDTieredSTOTokenPurchaseEventArgs,
   USDTieredSTOUnpauseEventArgs,
+  USDTieredSTOSetOraclesEventArgs,
+  USDTieredSTOUsageFeeDeductedEventArgs,
 } from './contract_wrappers/modules/sto/usd_tiered_sto_wrapper';
 export {
   GeneralTransferManager,

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,10 +701,10 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@polymathnetwork/abi-wrappers@4.0.0-beta.8":
-  version "4.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@polymathnetwork/abi-wrappers/-/abi-wrappers-4.0.0-beta.8.tgz#b540f159cadc719f89592f200a3ed0c914a4b221"
-  integrity sha512-vAiqTJ7UiA/rZN7mgZTdrLn0KcmRDMyjGGhP6ka5f1x663gDKhuc90pXUQtdOoD2j+vNhhaGZkBFDxSl6nXdOA==
+"@polymathnetwork/abi-wrappers@4.0.0-beta.9":
+  version "4.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@polymathnetwork/abi-wrappers/-/abi-wrappers-4.0.0-beta.9.tgz#ec1fba336879ee5164b78fffbe61fcac24d63ca5"
+  integrity sha512-ssV4bMbVo3fgAeXIlPu73vT7T5ZKO92OfS1CwmI/6pDmpTEHcQSajTUclIHJi/H2GXmfXlRuX+9afyoqmdFVRw==
   dependencies:
     "@0x/base-contract" "5.4.0"
     "@0x/utils" "4.5.2"


### PR DESCRIPTION
The module is now available to be pegged with other fiat currency.
Configure function is now accepting the contract address of the
stablecoins, the addresses of the custom oracles and the symbol of the
denominated currency.

BREAKING CHANGE: New USDTieredSTO configure interface